### PR TITLE
MM-16306 Adding fluentd deployment in central monitoring cluster.

### DIFF
--- a/chart-values/fluentd-elasticsearch_values.yaml
+++ b/chart-values/fluentd-elasticsearch_values.yaml
@@ -1,0 +1,9 @@
+annotations: {}
+elasticsearch:
+  buffer_chunk_limit: 200M
+  buffer_queue_limit: 64
+  host: internal.test.cloud.mattermost.com  
+  logstash_prefix: logstash
+  port: 80
+  scheme: http
+  ssl_version: TLSv1_2

--- a/terraform/aws/modules/cluster-post-installation/elasticsearch.tf
+++ b/terraform/aws/modules/cluster-post-installation/elasticsearch.tf
@@ -1,12 +1,9 @@
 resource "helm_release" "elasticsearch" {
   name       = "mattermost-cm-elasticsearch"
-  namespace  = "monitoring"
+  namespace  = "logging"
   repository = "${data.helm_repository.stable.metadata.0.name}"
   chart      = "stable/elasticsearch"
   values = [
     "${file("../../../../../chart-values/elasticsearch_values.yaml")}"
-  ]
-  depends_on = [
-    "kubernetes_namespace.monitoring"
   ]
 }

--- a/terraform/aws/modules/cluster-post-installation/fluentd.tf
+++ b/terraform/aws/modules/cluster-post-installation/fluentd.tf
@@ -1,5 +1,5 @@
-resource "helm_release" "kibana" {
-  name       = "mattermost-cm-kibana"
+resource "helm_release" "fluentd" {
+  name       = "mattermost-cm-fluentd"
   namespace  = "logging"
   repository = "${data.helm_repository.stable.metadata.0.name}"
   chart      = "stable/fluentd-elasticsearch"

--- a/terraform/aws/modules/cluster-post-installation/fluentd.tf
+++ b/terraform/aws/modules/cluster-post-installation/fluentd.tf
@@ -2,8 +2,8 @@ resource "helm_release" "kibana" {
   name       = "mattermost-cm-kibana"
   namespace  = "logging"
   repository = "${data.helm_repository.stable.metadata.0.name}"
-  chart      = "stable/kibana"
+  chart      = "stable/fluentd-elasticsearch"
   values = [
-    "${file("../../../../../chart-values/kibana_values.yaml")}"
+    "${file("../../../../../chart-values/fluentd-elasticsearch_values.yaml")}"
   ]
 }


### PR DESCRIPTION
Ticket -> https://mattermost.atlassian.net/browse/MM-16306 

- Adding fluentd deployment in central monitoring cluster. 
- Fixing namespaces for kibana and elasticsearch.