### PR TITLE
MM 16542 -  Automate Lambda deployment for Prometheus DNS Registration service.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
 # Select the environment you want to deploy Central Command Control cluster into.
 ENVIRONMENT = test
 
-
 all: build-app terraform-cluster terraform-post-cluster clean
 
 build-app:
 	$(MAKE) -C ./prometheus-dns-registration-service all
-
 
 terraform-cluster:
 	@echo "Deploying cluster infrastructure"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+# Select the environment you want to deploy Central Command Control cluster into.
+ENVIRONMENT = test
+
+
+all: build-app terraform-cluster terraform-post-cluster clean
+
+build-app:
+	$(MAKE) -C ./prometheus-dns-registration-service all
+
+
+terraform-cluster:
+	@echo "Deploying cluster infrastructure"
+	cd terraform/aws/environments/$(ENVIRONMENT)/cluster && \
+	terraform init && \
+	terraform apply --auto-approve
+
+terraform-post-cluster:
+	@echo "Deploying cluster post-installation infrastructure"
+	cd terraform/aws/environments/$(ENVIRONMENT)/cluster-post-installation && \
+	terraform init && \
+	terraform apply --auto-approve
+
+clean: 
+	$(MAKE) -C ./prometheus-dns-registration-service clean

--- a/terraform/aws/environments/test/cluster/main.tf
+++ b/terraform/aws/environments/test/cluster/main.tf
@@ -27,6 +27,7 @@ module "cluster" {
   kubeconfig_dir = "${var.kubeconfig_dir}"
   account_id = "${var.account_id}"
   volume_size = "${var.volume_size}"
+  private_hosted_zoneid = "${var.private_hosted_zoneid}"
   providers = {
     aws = "aws.deployment"
   }

--- a/terraform/aws/environments/test/cluster/variables.tf
+++ b/terraform/aws/environments/test/cluster/variables.tf
@@ -69,3 +69,8 @@ variable "volume_size" {
     default = "50"
     type = "string"
 }
+
+variable "private_hosted_zoneid" {
+    default = ""
+    type = "string"
+}

--- a/terraform/aws/modules/cluster/aws_auth_configmap.tf
+++ b/terraform/aws/modules/cluster/aws_auth_configmap.tf
@@ -10,11 +10,16 @@ resource "kubernetes_config_map" "aws_auth_configmap" {
     groups:
       - system:bootstrappers
       - system:nodes
+  - rolearn: "${aws_iam_role.lambda_role.arn}"
+    username: admin
+    groups:
+      - system:masters
   YAML
   }
   depends_on = [
     "aws_eks_cluster.cluster",
     "null_resource.cluster_services",
-    "aws_autoscaling_group.worker-asg"
+    "aws_autoscaling_group.worker-asg",
+    "aws_iam_role.lambda_role"
   ]
 }

--- a/terraform/aws/modules/cluster/prometheus-registration-service.tf
+++ b/terraform/aws/modules/cluster/prometheus-registration-service.tf
@@ -1,0 +1,135 @@
+resource "aws_iam_role" "lambda_role" {
+  name = "iam_for_lambda"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy" "EKSAccess" {
+  name = "test_policy"
+  role = "${aws_iam_role.lambda_role.id}"
+
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "sts:GetCallerIdentity",
+        "eks:DescribeCluster",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeVpcs",
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+
+resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole" {
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+  role       = "${aws_iam_role.lambda_role.name}"
+}
+
+resource "aws_iam_role_policy_attachment" "AmazonRoute53ReadOnlyAccess" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess"
+  role       = "${aws_iam_role.lambda_role.name}"
+}
+
+
+resource "aws_lambda_function" "prometheus_registration" {
+  filename      = "../../../../../prometheus-dns-registration-service/main.zip"
+  function_name = "prometheus-dns-registration-service"
+  role          = "${aws_iam_role.lambda_role.arn}"
+  handler       = "main"
+  timeout       = 120
+  source_code_hash = "${filebase64sha256("../../../../../prometheus-dns-registration-service/main.zip")}"
+  runtime = "go1.x"
+  vpc_config {
+    subnet_ids = ["${var.private_subnet_ids}"],
+    security_group_ids = ["${aws_security_group.lambda-sg.id}"]
+  }
+
+  environment {
+    variables = {
+      CLUSTER_NAME = "${var.deployment_name}",
+      CONFIG_MAP_NAME = "mattermost-cm-prometheus-server",
+      HOSTED_ZONE_ID =  "${var.private_hosted_zoneid}"
+    }
+  } 
+}
+
+resource "aws_security_group" "lambda-sg" {
+  name        = "${var.deployment_name}-lambda-sg"
+  description = "Prometheys DNS Registration Lambda"
+  vpc_id      = "${var.vpc_id}"
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.deployment_name}-lambda-sg"
+  }
+}
+
+resource "aws_cloudwatch_event_rule" "route53_updates" {
+    name = "prometheus-registration"
+    description = "Runs when a new Route53 record is deleted or created"
+    description = "Capture each AWS Console Sign In"
+    event_pattern = <<PATTERN
+    {
+      "source": [
+        "aws.route53"
+        ],
+      "detail-type": [
+        "AWS API Call via CloudTrail"
+        ],
+      "detail": {
+        "eventSource": [
+          "route53.amazonaws.com"
+          ],
+        "eventName": [
+          "ChangeResourceRecordSets"
+          ]
+      }
+    }
+  PATTERN
+}
+
+resource "aws_cloudwatch_event_target" "prometheus-registration" {
+    rule = "${aws_cloudwatch_event_rule.route53_updates.name}"
+    target_id = "prometheus_registration"
+    arn = "${aws_lambda_function.prometheus_registration.arn}"
+}
+
+resource "aws_lambda_permission" "allow_cloudwatch_to_call_prometheus_registration" {
+    statement_id = "AllowExecutionFromCloudWatch"
+    action = "lambda:InvokeFunction"
+    function_name = "${aws_lambda_function.prometheus_registration.function_name}"
+    principal = "events.amazonaws.com"
+    source_arn = "${aws_cloudwatch_event_rule.route53_updates.arn}"
+}

--- a/terraform/aws/modules/cluster/variables.tf
+++ b/terraform/aws/modules/cluster/variables.tf
@@ -26,3 +26,5 @@ variable "kubeconfig_dir" {}
 variable "account_id" {}
 
 variable "volume_size"{}
+
+variable "private_hosted_zoneid"{}


### PR DESCRIPTION
Ticket -> https://mattermost.atlassian.net/browse/MM-16542 

- Automate Prometheus Microservice deployment.
     -- With this code the microservice is deployed as part fo the Central Command Control cluster.
     -- No additional configuration is needed.
     -- Only the private private_hosted_zoneid variable is required for this additional deployment
- A Makefile is added that when the environment is specified, by running make all it will deploy the whole Central Command and Control cluster infrastructure in the specified environment.