### PR TITLE
MM-16549 Adding prometheus client configuration for central command and control cluster

### DIFF
--- a/chart-values/prometheus-client_values.yaml
+++ b/chart-values/prometheus-client_values.yaml
@@ -1,0 +1,17 @@
+nodeExporter:
+  hostNetwork: false
+  service:
+    hostPort: 9101
+    loadBalancerIP: ""
+    loadBalancerSourceRanges: []
+    servicePort: 9101
+    type: ClusterIP
+
+
+server:
+  ingress:
+    enabled: true
+    annotations: 
+      kubernetes.io/ingress.class: nginx-internal
+    hosts:
+      - prometheus.internal.example.com

--- a/terraform/aws/modules/cluster-post-installation/elasticsearch.tf
+++ b/terraform/aws/modules/cluster-post-installation/elasticsearch.tf
@@ -3,6 +3,7 @@ resource "helm_release" "elasticsearch" {
   namespace  = "logging"
   repository = "${data.helm_repository.stable.metadata.0.name}"
   chart      = "stable/elasticsearch"
+  timeout    = 600
   values = [
     "${file("../../../../../chart-values/elasticsearch_values.yaml")}"
   ]

--- a/terraform/aws/modules/cluster-post-installation/prometheus-client.tf
+++ b/terraform/aws/modules/cluster-post-installation/prometheus-client.tf
@@ -1,0 +1,13 @@
+resource "helm_release" "prometheus-client" {
+  name       = "mattermost-cm-prometheus-client"
+  namespace  = "monitoring"
+  repository = "${data.helm_repository.stable.metadata.0.name}"
+  chart      = "stable/prometheus"
+  wait       = false
+  values = [
+    "${file("../../../../../chart-values/prometheus-client_values.yaml")}"
+  ]
+  depends_on = [
+    "kubernetes_namespace.monitoring"
+  ]
+}


### PR DESCRIPTION
Ticket -> https://mattermost.atlassian.net/browse/MM-16549

- Add configuration of Prometheus client
- Prometheus client will be used to get the metrics of the central command and control cluster, which will be analysed by the central monitoring Prometheus application.