### PR TITLE
Mm 16550 Adding private endpoint access for internal traffic

### DIFF
--- a/terraform/aws/modules/cluster/master.tf
+++ b/terraform/aws/modules/cluster/master.tf
@@ -11,6 +11,8 @@ resource "aws_eks_cluster" "cluster" {
   vpc_config {
     security_group_ids = ["${aws_security_group.cluster-sg.id}"]
     subnet_ids         = ["${var.public_subnet_ids}","${var.private_subnet_ids}"]
+    endpoint_private_access = true
+    endpoint_public_access = true
   }
 
   depends_on = [

--- a/terraform/aws/modules/cluster/master_sg.tf
+++ b/terraform/aws/modules/cluster/master_sg.tf
@@ -27,3 +27,13 @@ resource "aws_security_group_rule" "cluster-ingress-workstation-https" {
   to_port           = 443
   type              = "ingress"
 }
+
+resource "aws_security_group_rule" "prometheus-lambda-ingress" {
+  description              = "Allow prometheus lambda registration service to communicate with cluster"
+  from_port                = 443
+  protocol                 = "tcp"
+  security_group_id        = "${aws_security_group.cluster-sg.id}"
+  source_security_group_id = "${aws_security_group.lambda-sg.id}"
+  to_port                  = 443
+  type                     = "ingress"
+}


### PR DESCRIPTION
Ticket -> https://mattermost.atlassian.net/browse/MM-16550

As discussed with @jwilander we will keep both private and public endpoint at the moment. The private is used for all traffic between master and nodes, as well as the prometheus registration lambda application. Public is used only for k8s api commands and only specific members have access.

- We cannot fully move to only private endpoint at the moment as VPN service is sitting in a different VPC and although there is transit gtw the resolution of the k8s endpoint (which is using private hosted zone in the background) is not possible without manually setting dns forwarding. 

- Different solutions will be examined closer to production move.
- The ingress rule in the terraform code is needed because of the private endpoint which lambda is using to communicate.