### PR TITLE
MM-16551 Adding automatic Route53 registration for central command cluster services

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # Select the environment you want to deploy Central Command Control cluster into.
 ENVIRONMENT = test
 
-all: build-app terraform-cluster terraform-post-cluster clean
+all: build-app terraform-cluster terraform-post-cluster terraform-route53 clean
 
 build-app:
 	$(MAKE) -C ./prometheus-dns-registration-service all
@@ -15,6 +15,12 @@ terraform-cluster:
 terraform-post-cluster:
 	@echo "Deploying cluster post-installation infrastructure"
 	cd terraform/aws/environments/$(ENVIRONMENT)/cluster-post-installation && \
+	terraform init && \
+	terraform apply --auto-approve
+
+terraform-route53:
+	@echo "Registering services with Route53"
+	cd terraform/aws/environments/$(ENVIRONMENT)/route53-registration && \
 	terraform init && \
 	terraform apply --auto-approve
 

--- a/terraform/aws/environments/dev/cluster-post-installation/main.tf
+++ b/terraform/aws/environments/dev/cluster-post-installation/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.11"
   backend "s3" {
     bucket = "terraform-cloud-monitoring-state-bucket-dev"
-    key    = "central-monitoring-cluster-post-installation"
+    key    = "mattermost-central-command-control-post-installation"
     region = "us-east-1"
   }
 }

--- a/terraform/aws/environments/dev/cluster/main.tf
+++ b/terraform/aws/environments/dev/cluster/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.11"
   backend "s3" {
     bucket = "terraform-cloud-monitoring-state-bucket-dev"
-    key    = "central-monitoring-cluster"
+    key    = "mattermost-central-command-control"
     region = "us-east-1"
   }
 }
@@ -27,6 +27,7 @@ module "cluster" {
   kubeconfig_dir = "${var.kubeconfig_dir}"
   account_id = "${var.account_id}"
   volume_size = "${var.volume_size}"
+  private_hosted_zoneid = "${var.private_hosted_zoneid}"
   providers = {
     aws = "aws.deployment"
   }

--- a/terraform/aws/environments/dev/cluster/variables.tf
+++ b/terraform/aws/environments/dev/cluster/variables.tf
@@ -49,11 +49,6 @@ variable "account_id" {
     type = "string"
 }
 
-variable "environment" {
-    default = "dev"
-    type = "string"
-}
-
 variable "cidr_blocks" {
     default = [""]
     type = "list"
@@ -67,5 +62,10 @@ variable "kubeconfig_dir" {
 
 variable "volume_size" {
     default = "50"
+    type = "string"
+}
+
+variable "private_hosted_zoneid" {
+    default = ""
     type = "string"
 }

--- a/terraform/aws/environments/dev/route53-registration/main.tf
+++ b/terraform/aws/environments/dev/route53-registration/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 0.11"
+  backend "s3" {
+    bucket = "terraform-cloud-monitoring-state-bucket-dev"
+    key    = "mattermost-central-command-control-route53-registration"
+    region = "us-east-1"
+  }
+}
+
+
+provider "aws" {
+  region = "${var.region}"
+  alias  = "route53-registration"
+}
+
+
+module "route53-registration" {
+  source = "../../../modules/route53-registration"
+  deployment_name = "${var.deployment_name}"
+  kubeconfig_dir = "${var.kubeconfig_dir}"
+  private_hosted_zoneid = "${var.private_hosted_zoneid}"
+  public_hosted_zoneid = "${var.public_hosted_zoneid}"
+  providers = {
+    aws = "aws.route53-registration"
+  }
+}

--- a/terraform/aws/environments/dev/route53-registration/variables.tf
+++ b/terraform/aws/environments/dev/route53-registration/variables.tf
@@ -1,0 +1,23 @@
+variable "deployment_name" {
+    default = "mattermost-central-command-control"
+    type = "string"
+}
+variable "region" {
+    default = "us-east-1"
+    type = "string"
+}
+
+variable "kubeconfig_dir" {
+    default = "$HOME/generated"
+    type = "string"
+}
+
+variable "public_hosted_zoneid" {
+    default = ""
+    type = "string"
+}
+
+variable "private_hosted_zoneid" {
+    default = ""
+    type = "string"
+}

--- a/terraform/aws/environments/test/cluster/variables.tf
+++ b/terraform/aws/environments/test/cluster/variables.tf
@@ -49,11 +49,6 @@ variable "account_id" {
     type = "string"
 }
 
-variable "environment" {
-    default = "test"
-    type = "string"
-}
-
 variable "cidr_blocks" {
     default = [""]
     type = "list"

--- a/terraform/aws/environments/test/route53-registration/main.tf
+++ b/terraform/aws/environments/test/route53-registration/main.tf
@@ -1,0 +1,26 @@
+terraform {
+  required_version = ">= 0.11"
+  backend "s3" {
+    bucket = "terraform-cloud-monitoring-state-bucket-test"
+    key    = "mattermost-central-command-control-route53-registration"
+    region = "us-east-1"
+  }
+}
+
+
+provider "aws" {
+  region = "${var.region}"
+  alias  = "route53-registration"
+}
+
+
+module "route53-registration" {
+  source = "../../../modules/route53-registration"
+  deployment_name = "${var.deployment_name}"
+  kubeconfig_dir = "${var.kubeconfig_dir}"
+  private_hosted_zoneid = "${var.private_hosted_zoneid}"
+  public_hosted_zoneid = "${var.public_hosted_zoneid}"
+  providers = {
+    aws = "aws.route53-registration"
+  }
+}

--- a/terraform/aws/environments/test/route53-registration/variables.tf
+++ b/terraform/aws/environments/test/route53-registration/variables.tf
@@ -1,0 +1,23 @@
+variable "deployment_name" {
+    default = "mattermost-central-command-control"
+    type = "string"
+}
+variable "region" {
+    default = "us-east-1"
+    type = "string"
+}
+
+variable "kubeconfig_dir" {
+    default = "$HOME/generated"
+    type = "string"
+}
+
+variable "public_hosted_zoneid" {
+    default = ""
+    type = "string"
+}
+
+variable "private_hosted_zoneid" {
+    default = ""
+    type = "string"
+}

--- a/terraform/aws/modules/route53-registration/providers.tf
+++ b/terraform/aws/modules/route53-registration/providers.tf
@@ -1,0 +1,15 @@
+data "aws_eks_cluster_auth" "cluster_auth" {
+  name = "${var.deployment_name}"
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = "${var.deployment_name}"
+}
+
+provider "kubernetes" {
+  host                   = "${data.aws_eks_cluster.cluster.endpoint}"
+  cluster_ca_certificate = "${base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)}"
+  token                  = "${data.aws_eks_cluster_auth.cluster_auth.token}"
+  load_config_file       = false
+  config_path            = "${var.kubeconfig_dir}/kubeconfig"
+}

--- a/terraform/aws/modules/route53-registration/route53.tf
+++ b/terraform/aws/modules/route53-registration/route53.tf
@@ -1,0 +1,71 @@
+data "kubernetes_service" "nginx-internal" {
+  metadata {
+    name = "mattermost-cm-nginx-internal-nginx-ingress-controller"
+    namespace = "network"
+  }
+}
+
+data "kubernetes_service" "nginx" {
+  metadata {
+    name = "mattermost-cm-nginx-nginx-ingress-controller"
+    namespace = "network"
+  }
+}
+
+#Public records
+resource "aws_route53_record" "prometheus" {
+  zone_id = "${var.public_hosted_zoneid}"
+  name    = "prometheus"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.kubernetes_service.nginx.load_balancer_ingress.0.hostname}"]
+}
+
+resource "aws_route53_record" "grafana" {
+  zone_id = "${var.public_hosted_zoneid}"
+  name    = "grafana"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.kubernetes_service.nginx.load_balancer_ingress.0.hostname}"]
+}
+
+resource "aws_route53_record" "kibana" {
+  zone_id = "${var.public_hosted_zoneid}"
+  name    = "kibana"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.kubernetes_service.nginx.load_balancer_ingress.0.hostname}"]
+}
+
+resource "aws_route53_record" "auth" {
+  zone_id = "${var.public_hosted_zoneid}"
+  name    = "auth"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.kubernetes_service.nginx.load_balancer_ingress.0.hostname}"]
+}
+
+#Private records
+resource "aws_route53_record" "prometheus-client" {
+  zone_id = "${var.private_hosted_zoneid}"
+  name    = "client.prometheus"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.kubernetes_service.nginx-internal.load_balancer_ingress.0.hostname}"]
+}
+
+resource "aws_route53_record" "elasticsearch" {
+  zone_id = "${var.private_hosted_zoneid}"
+  name    = "elasticsearch"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.kubernetes_service.nginx-internal.load_balancer_ingress.0.hostname}"]
+}
+
+resource "aws_route53_record" "provisioner" {
+  zone_id = "${var.private_hosted_zoneid}"
+  name    = "provisioner"
+  type    = "CNAME"
+  ttl     = "60"
+  records = ["${data.kubernetes_service.nginx-internal.load_balancer_ingress.0.hostname}"]
+}

--- a/terraform/aws/modules/route53-registration/variables.tf
+++ b/terraform/aws/modules/route53-registration/variables.tf
@@ -1,0 +1,7 @@
+variable "deployment_name" {}
+
+variable "kubeconfig_dir" {}
+
+variable "public_hosted_zoneid" {}
+
+variable "private_hosted_zoneid" {}


### PR DESCRIPTION
Ticket -> https://mattermost.atlassian.net/browse/MM-16551

This PR adds:
- A new module to handle automatic Route53 registration of all central command and control cluster services. In more detail:
   - Prometheus
   - Prometheus client
   - Grafana
   - Kibana
   - Elasticsearch
   - Mattermost Provisioner
   - Auth service
- Adapts the dev environment to follow the latest naming convention (central command and control cluster)
- Updates Makefile to deploy the whole infrastructure with a single command