### PR TITLE
MM-20770 Adding policies for provisioner user

### DIFF
--- a/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/main.tf
@@ -52,6 +52,7 @@ module "cluster-post-installation" {
   mattermost_cloud_secrets_private_dns         = var.mattermost_cloud_secrets_private_dns
   mattermost_cloud_secrets_private_route53_id  = var.mattermost_cloud_secrets_private_route53_id
   mattermost_cloud_secrets_route53_id          = var.mattermost_cloud_secrets_route53_id
+  provisioner_user = var.provisioner_user
 
   providers = {
     aws = aws.post-deployment

--- a/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/variables.tf
+++ b/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/variables.tf
@@ -160,3 +160,5 @@ variable "mattermost_cloud_secrets_private_dns" {}
 variable "mattermost_cloud_secrets_private_route53_id" {}
 
 variable "mattermost_cloud_secrets_route53_id" {}
+
+variable "provisioner_user" {}

--- a/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/main.tf
@@ -52,6 +52,7 @@ module "cluster-post-installation" {
   mattermost_cloud_secrets_private_dns         = var.mattermost_cloud_secrets_private_dns
   mattermost_cloud_secrets_private_route53_id  = var.mattermost_cloud_secrets_private_route53_id
   mattermost_cloud_secrets_route53_id          = var.mattermost_cloud_secrets_route53_id
+  provisioner_user = var.provisioner_user
 
   providers = {
     aws = aws.post-deployment

--- a/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/variables.tf
+++ b/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/variables.tf
@@ -190,3 +190,5 @@ variable "mattermost_cloud_secrets_route53_id" {
   type    = string
   default = ""
 }
+
+variable "provisioner_user" {}

--- a/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/main.tf
@@ -53,6 +53,7 @@ module "cluster-post-installation" {
   mattermost_cloud_secrets_private_dns = var.mattermost_cloud_secrets_private_dns
   mattermost_cloud_secrets_private_route53_id = var.mattermost_cloud_secrets_private_route53_id
   mattermost_cloud_secrets_route53_id = var.mattermost_cloud_secrets_route53_id
+  provisioner_user = var.provisioner_user
 
   providers = {
     aws = aws.post-deployment

--- a/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/variables.tf
+++ b/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/variables.tf
@@ -160,3 +160,5 @@ variable "mattermost_cloud_secrets_private_dns" {}
 variable "mattermost_cloud_secrets_private_route53_id" {}
 
 variable "mattermost_cloud_secrets_route53_id" {}
+
+variable "provisioner_user" {}

--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -1,0 +1,350 @@
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_policy" "route53" {
+  name        = "mattermost-provisioner-route53-policy"
+  path        = "/"
+  description = "Route53 permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "route53",
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets",
+                "route53:ListResourceRecordSets"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "rds" {
+  name        = "mattermost-provisioner-rds-policy"
+  path        = "/"
+  description = "RDS permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "rds0",
+            "Effect": "Allow",
+            "Action": [
+                "rds:CreateDBCluster",
+                "rds:DeleteDBCluster",
+                "rds:DescribeDBClusters"
+            ],
+            "Resource": [
+                "arn:aws:rds:us-east-1:${data.aws_caller_identity.current.account_id}:cluster:cloud-*",
+                "arn:aws:rds:us-east-1:${data.aws_caller_identity.current.account_id}:subgrp:mattermost-databases*"
+            ]
+        },
+        {
+            "Sid": "rds1",
+            "Effect": "Allow",
+            "Action": [
+                "rds:CreateDBInstance"
+            ],
+            "Resource": [
+                "arn:aws:rds:us-east-1:${data.aws_caller_identity.current.account_id}:db:cloud-*",
+                "arn:aws:rds:us-east-1:${data.aws_caller_identity.current.account_id}:cluster:cloud-*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "s3" {
+  name        = "mattermost-provisioner-s3-policy"
+  path        = "/"
+  description = "S3 permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListAllMyBuckets"
+            ],
+            "Resource": "arn:aws:s3:::*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetBucketLocation"
+            ],
+            "Resource": "arn:aws:s3:::mattermost-kops-state-${var.environment}"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:PutObjectAcl",
+                "s3:GetObject",
+                "s3:GetObjectAcl",
+                "s3:DeleteObject",
+                "s3:GetObjectVersionAcl"
+            ],
+            "Resource": "arn:aws:s3:::mattermost-kops-state-${var.environment}/*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:CreateBucket",
+                "s3:PutBucketPublicAccessBlock",
+                "s3:GetBucketPublicAccessBlock"
+            ],
+            "Resource": "arn:aws:s3:::cloud-*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "secrets_manager" {
+  name        = "mattermost-provisioner-secretsmanager-policy"
+  path        = "/"
+  description = "Secrets Manager permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "secrets0",
+            "Effect": "Allow",
+            "Action": [
+                "secretsmanager:CreateSecret",
+                "secretsmanager:DeleteSecret",
+                "secretsmanager:GetSecretValue"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "ec2" {
+  name        = "mattermost-provisioner-ec2-policy"
+  path        = "/"
+  description = "EC2 permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "ec20",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:AttachVolume",
+                "ec2:AuthorizeSecurityGroupIngress",
+                "ec2:DescribeInstances",
+                "ec2:DeleteTags",
+                "ec2:DescribeRegions",
+                "ec2:DescribeSnapshots",
+                "ec2:DeleteVolume",
+                "ec2:DescribeVolumeStatus",
+                "ec2:DeleteNetworkInterfacePermission",
+                "ec2:StartInstances",
+                "ec2:CreateNetworkInterfacePermission",
+                "ec2:DescribeAvailabilityZones",
+                "ec2:DescribeVolumes",
+                "ec2:DescribeReservedInstances",
+                "ec2:DescribeReservedInstancesListings",
+                "ec2:DescribeInstanceStatus",
+                "ec2:DetachVolume",
+                "ec2:AuthorizeSecurityGroupEgress",
+                "ec2:ModifyVolume",
+                "ec2:TerminateInstances",
+                "ec2:DescribeTags",
+                "ec2:CreateTags",
+                "ec2:RunInstances",
+                "ec2:StopInstances",
+                "ec2:DescribeSecurityGroups",
+                "ec2:CreateVolume",
+                "ec2:DescribeImages",
+                "ec2:DescribeVpcs",
+                "ec2:AttachNetworkInterface",
+                "ec2:DescribeSubnets",
+                "ec2:ImportKeyPair",
+                "ec2:DeleteKeyPair",
+                "elasticloadbalancing:DescribeTags",
+                "elasticloadbalancing:CreateLoadBalancer",
+                "elasticloadbalancing:DescribeTargetGroups",
+                "elasticloadbalancing:DescribeLoadBalancerAttributes",
+                "elasticloadbalancing:DescribeLoadBalancers",
+                "elasticloadbalancing:ModifyLoadBalancerAttributes",
+                "elasticloadbalancing:CreateLoadBalancerListeners",
+                "elasticloadbalancing:DeleteLoadBalancer",
+                "elasticloadbalancing:ConfigureHealthCheck",
+                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
+                "elasticloadbalancing:AttachLoadBalancerToSubnets",
+                "elasticloadbalancing:AddTags",
+                "autoscaling:CreateLaunchConfiguration",
+                "autoscaling:DescribeTags",
+                "autoscaling:DescribeLaunchConfigurations",
+                "autoscaling:CreateAutoScalingGroup",
+                "autoscaling:DeleteLaunchConfiguration",
+                "autoscaling:DeleteAutoScalingGroup",
+                "autoscaling:DescribeScalingActivities",
+                "autoscaling:DescribeAutoScalingGroups",
+                "autoscaling:UpdateAutoScalingGroup",
+                "autoscaling:EnableMetricsCollection",
+                "autoscaling:AttachLoadBalancers",
+                "autoscaling:DetachLoadBalancers"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "vpc" {
+  name        = "mattermost-provisioner-vpc-policy"
+  path        = "/"
+  description = "VPC permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "vpc0",
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DeleteTags",
+                "ec2:CreateTags",
+                "ec2:CreateSecurityGroup",
+                "ec2:DeleteSecurityGroup",
+                "ec2:Describe*",
+                "ec2:RevokeSecurityGroupEgress",
+                "ec2:RevokeSecurityGroupIngress"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "iam" {
+  name        = "mattermost-provisioner-iam-policy"
+  path        = "/"
+  description = "IAM permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "iam0",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListRoles",
+                "iam:ListInstanceProfiles"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Sid": "iam1",
+            "Effect": "Allow",
+            "Action": [
+                "iam:ListInstanceProfilesForRole",
+                "iam:CreateRole",
+                "iam:GetRole",
+                "iam:DeleteRole",
+                "iam:PutRolePolicy",
+                "iam:GetRolePolicy",
+                "iam:DeleteRolePolicy",
+                "iam:CreateInstanceProfile",
+                "iam:GetInstanceProfile",
+                "iam:RemoveRoleFromInstanceProfile",
+                "iam:DeleteInstanceProfile",
+                "iam:AddRoleToInstanceProfile",
+                "iam:PassRole"
+            ],
+            "Resource": [
+                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/masters.*",
+                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/nodes.*",
+                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/masters.*",
+                "arn:aws:iam::${data.aws_caller_identity.current.account_id}:instance-profile/nodes.*"
+            ]
+        },
+        {
+            "Sid": "iam2",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetUser",
+                "iam:CreateUser",
+                "iam:ListAttachedUserPolicies",
+                "iam:ListAccessKeys",
+                "iam:DeleteUser",
+                "iam:AttachUserPolicy",
+                "iam:DetachUserPolicy",
+                "iam:CreateAccessKey",
+                "iam:DeleteAccessKey"
+            ],
+            "Resource": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/cloud-*"
+        },
+        {
+            "Sid": "iam3",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetPolicy",
+                "iam:CreatePolicy",
+                "iam:DeletePolicy"
+            ],
+            "Resource": "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/cloud-*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy_attachment" "attach_route53" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.route53.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_rds" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.rds.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_s3" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.s3.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_secrets_manager" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.secrets_manager.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_ec2" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.ec2.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_vpc" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.vpc.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_iam" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.iam.arn
+}

--- a/terraform/aws/modules/cluster-post-installation/variables.tf
+++ b/terraform/aws/modules/cluster-post-installation/variables.tf
@@ -71,3 +71,5 @@ variable "prometheus_tls_key" {}
 variable "kibana_tls_crt" {}
 
 variable "kibana_tls_key" {}
+
+variable "provisioner_user" {}

--- a/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
+++ b/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
@@ -1,0 +1,19 @@
+resource "aws_db_subnet_group" "provisioner_db_subnet_group" {
+
+for_each = toset(var.vpc_cidrs)
+
+name       = "mattermost-provisioner-db-sg-${join("", split(".", split("/", each.value)[0]))}"
+  
+subnet_ids         = [
+    aws_subnet.private_1a[each.value]["id"],
+    aws_subnet.private_1b[each.value]["id"],
+    aws_subnet.private_1c[each.value]["id"],
+    aws_subnet.private_1d[each.value]["id"],
+    aws_subnet.private_1e[each.value]["id"],
+    aws_subnet.private_1f[each.value]["id"]
+]
+
+tags = {
+    DBSubnetGroupType = "provisioning"
+    }
+}

--- a/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
+++ b/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
@@ -2,7 +2,7 @@ resource "aws_db_subnet_group" "provisioner_db_subnet_group" {
 
 for_each = toset(var.vpc_cidrs)
 
-name       = "mattermost-provisioner-db-sg-${join("", split(".", split("/", each.value)[0]))}"
+name       = "mattermost-provisioner-db-${data.aws_vpc.vpc_ids[each.value]["id"]}"
   
 subnet_ids         = [
     aws_subnet.private_1a[each.value]["id"],

--- a/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
+++ b/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
@@ -13,7 +13,10 @@ subnet_ids         = [
     aws_subnet.private_1f[each.value]["id"]
 ]
 
-tags = {
-    DBSubnetGroupType = "provisioning"
-    }
+tags = merge(
+    {
+     "MattermostCloudInstallationDatabase" = "MYSQL/Aurora"
+    },
+    var.tags
+  )
 }

--- a/terraform/aws/modules/subnet-and-networking/security_groups.tf
+++ b/terraform/aws/modules/subnet-and-networking/security_groups.tf
@@ -37,7 +37,7 @@ resource "aws_security_group" "db_sg" {
   tags = merge(
     {
      "Name" = format("%s-%s-db-sg", var.name, join("", split(".", split("/", each.value)[0]))),
-     "DatabaseType" = "MYSQL/Aurora"
+     "MattermostCloudInstallationDatabase" = "MYSQL/Aurora"
     },
     var.tags
   )

--- a/terraform/aws/modules/subnet-and-networking/security_groups.tf
+++ b/terraform/aws/modules/subnet-and-networking/security_groups.tf
@@ -28,6 +28,21 @@ resource "aws_security_group" "worker_sg" {
   )
 }
 
+resource "aws_security_group" "db_sg" {
+  for_each = toset(var.vpc_cidrs)
+
+  name        = format("%s-%s-db-sg", var.name, join("", split(".", split("/", each.value)[0])))
+  description = "RDS Database Security Group"
+  vpc_id = data.aws_vpc.vpc_ids[each.value]["id"]
+  tags = merge(
+    {
+     "Name" = format("%s-%s-db-sg", var.name, join("", split(".", split("/", each.value)[0]))),
+     "DatabaseType" = "MYSQL/Aurora"
+    },
+    var.tags
+  )
+}
+
 # Master Rules
 resource "aws_security_group_rule" "master_egress" {
   for_each = toset(var.vpc_cidrs)
@@ -87,5 +102,18 @@ resource "aws_security_group_rule" "worker_ingress_master" {
   protocol          = "-1"
   security_group_id = aws_security_group.worker_sg[each.value]["id"]
   to_port           = 0
+  type              = "ingress"
+}
+
+# DB Rules
+resource "aws_security_group_rule" "db_ingress_worker" {
+  for_each = toset(var.vpc_cidrs)
+
+  source_security_group_id = aws_security_group.worker_sg[each.value]["id"]
+  description       = "Ingress Traffic from Worker Nodes"
+  from_port         = 3306
+  protocol          = "TCP"
+  security_group_id = aws_security_group.db_sg[each.value]["id"]
+  to_port           = 3306
   type              = "ingress"
 }

--- a/terraform/aws/modules/subnet-and-networking/subnet.tf
+++ b/terraform/aws/modules/subnet-and-networking/subnet.tf
@@ -108,6 +108,11 @@ resource "aws_subnet" "public_1a" {
     },
     var.tags
   )
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 
 resource "aws_subnet" "public_1b" {
@@ -122,6 +127,11 @@ resource "aws_subnet" "public_1b" {
     },
     var.tags
   )
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 
 resource "aws_subnet" "public_1c" {
@@ -137,6 +147,11 @@ resource "aws_subnet" "public_1c" {
     },
     var.tags
   )
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 
 resource "aws_subnet" "public_1d" {
@@ -152,6 +167,11 @@ resource "aws_subnet" "public_1d" {
     },
     var.tags
   )
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 
 resource "aws_subnet" "public_1e" {
@@ -167,6 +187,11 @@ resource "aws_subnet" "public_1e" {
     },
     var.tags
   )
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 
 resource "aws_subnet" "public_1f" {
@@ -182,5 +207,10 @@ resource "aws_subnet" "public_1f" {
     },
     var.tags
   )
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
 }
 


### PR DESCRIPTION
This PR add the Terraform code for:

- Creation of IAM Policies
- Attachment of policies to existing provisioner user
- Creation of DB Subnet Groups in each provisioning VPC
- Creation of RDS Security Group in each provisioning VPC
- Ignoring of tags after their creation in public subnets to avoid overwriting of kops k8s tags