### PR TITLE
MM-18599 Moving Provisioner to use Internal nginx and internal ELB

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/provisioner.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner.tf
@@ -482,7 +482,7 @@ resource "kubernetes_ingress" "mattermost_cloud_ingress" {
     namespace = var.mattermost-cloud-namespace
 
     annotations = {
-      "kubernetes.io/ingress.class" = "nginx"
+      "kubernetes.io/ingress.class" = "nginx-internal"
     }
   }
 

--- a/terraform/aws/modules/route53-registration/route53.tf
+++ b/terraform/aws/modules/route53-registration/route53.tf
@@ -42,5 +42,5 @@ resource "aws_route53_record" "provisioner" {
   name    = "provisioner"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-internal.load_balancer_ingress.0.hostname]
 }


### PR DESCRIPTION
Moving Provisioner to use Internal nginx and internal ELB
- Changes pushed in all environments
- Provisioner tested both via direct DNS and AUTH function.