### PR TITLE
MM-19103 Turning C&C API private and removing non used public NGINX

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/ingress.tf
+++ b/terraform/aws/modules/cluster-post-installation/ingress.tf
@@ -1,9 +1,0 @@
-resource "helm_release" "nginx" {
-  name       = "mattermost-cm-nginx"
-  namespace  = "network"
-  repository = data.helm_repository.stable.metadata.0.name
-  chart      = "stable/nginx-ingress"
-  depends_on = [
-    kubernetes_namespace.network
-  ]
-}

--- a/terraform/aws/modules/cluster/master.tf
+++ b/terraform/aws/modules/cluster/master.tf
@@ -12,7 +12,7 @@ resource "aws_eks_cluster" "cluster" {
     security_group_ids = [aws_security_group.cluster-sg.id]
     subnet_ids         = flatten([var.public_subnet_ids, var.private_subnet_ids])
     endpoint_private_access = true
-    endpoint_public_access = true
+    endpoint_public_access = false
   }
 
   depends_on = [


### PR DESCRIPTION
- Make C&C API endpoint private
- Remove old non used public NGINX controller. All apps should be using internal.