### PR TITLE
Alerting is not an array, fixing

### DIFF
--- a/prometheus-dns-registration-service/main.go
+++ b/prometheus-dns-registration-service/main.go
@@ -37,7 +37,7 @@ type config struct {
 		ScrapeTimeOut      string `yaml:"scrape_timeout"`
 	} `yaml:"global"`
 	RuleFiles []string `yaml:"rule_files"`
-	Alerting  []struct {
+	Alerting  struct {
 		Alertmanagers []struct {
 			Scheme        string `yaml:"scheme"`
 			StaticConfigs []struct {


### PR DESCRIPTION
#### Summary
if the prometheus yaml config have setup Alertmanager the config was reverted and remove the alertmanager config, this fixes the issue

