### PR TITLE
MM-22260 Adding FLUX for provisioner update

### DIFF
--- a/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/main.tf
@@ -52,6 +52,11 @@ module "cluster-post-installation" {
   mattermost_cloud_secrets_keep_filestore_data = var.mattermost_cloud_secrets_keep_filestore_data
   mattermost_cloud_secrets_keep_database_data  = var.mattermost_cloud_secrets_keep_database_data
   provisioner_user                             = var.provisioner_user
+  git_url                                      = var.git_url
+  git_path                                     = var.git_path
+  git_user                                     = var.git_user
+  git_email                                    = var.git_email
+  ssh_known_hosts                              = var.ssh_known_hosts
 
   providers = {
     aws = aws.post-deployment

--- a/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/output.tf
+++ b/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/output.tf
@@ -1,0 +1,4 @@
+output "flux-deployment" {
+  value = module.cluster-post-installation.post_installation_message
+}
+

--- a/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/main.tf
@@ -52,6 +52,11 @@ module "cluster-post-installation" {
   mattermost_cloud_secrets_keep_filestore_data = var.mattermost_cloud_secrets_keep_filestore_data
   mattermost_cloud_secrets_keep_database_data  = var.mattermost_cloud_secrets_keep_database_data
   provisioner_user                             = var.provisioner_user
+  git_url                                      = var.git_url
+  git_path                                     = var.git_path
+  git_user                                     = var.git_user
+  git_email                                    = var.git_email
+  ssh_known_hosts                              = var.ssh_known_hosts
 
   providers = {
     aws = aws.post-deployment

--- a/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/output.tf
+++ b/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/output.tf
@@ -1,0 +1,4 @@
+output "flux-deployment" {
+  value = module.cluster-post-installation.post_installation_message
+}
+

--- a/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/main.tf
@@ -53,7 +53,12 @@ module "cluster-post-installation" {
   mattermost_cloud_secrets_keep_filestore_data = var.mattermost_cloud_secrets_keep_filestore_data
   mattermost_cloud_secrets_keep_database_data  = var.mattermost_cloud_secrets_keep_database_data
   provisioner_user                             = var.provisioner_user
-
+  git_url                                      = var.git_url
+  git_path                                     = var.git_path
+  git_user                                     = var.git_user
+  git_email                                    = var.git_email
+  ssh_known_hosts                              = var.ssh_known_hosts
+                  
   providers = {
     aws = aws.post-deployment
   }

--- a/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/output.tf
+++ b/terraform/aws/environments/test/4-command-and-control/3-cluster-post-installation/output.tf
@@ -1,0 +1,4 @@
+output "flux-deployment" {
+  value = module.cluster-post-installation.post_installation_message
+}
+

--- a/terraform/aws/modules/cluster-post-installation/flux.tf
+++ b/terraform/aws/modules/cluster-post-installation/flux.tf
@@ -1,0 +1,50 @@
+resource "null_resource" "flux_crd" {
+  provisioner "local-exec" {
+    command = "kubectl --kubeconfig ${var.kubeconfig_dir}/kubeconfig apply -f https://raw.githubusercontent.com/fluxcd/helm-operator/master/deploy/flux-helm-release-crd.yaml" 
+  }
+}
+
+resource "helm_release" "flux" {
+  name  = "mattermost-cm-flux"
+  chart = "fluxcd/flux"
+  namespace  = "flux"
+
+  set {
+    name  = "git.url"
+    value = var.git_url
+  }
+
+  set {
+    name  = "git.path"
+    value = var.git_path
+  }
+
+  set {
+    name  = "git.user"
+    value = var.git_user
+  }
+
+  set {
+    name  = "git.email"
+    value = var.git_email
+  }
+
+  set_string {
+    name  = "ssh.known_hosts"
+    value = var.ssh_known_hosts
+  }
+
+  set {
+    name  = "prometheus.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "registry.disableScanning"
+    value = "true"
+  }
+  depends_on = [
+    kubernetes_namespace.flux,
+    null_resource.flux_crd
+  ]
+}

--- a/terraform/aws/modules/cluster-post-installation/namespaces.tf
+++ b/terraform/aws/modules/cluster-post-installation/namespaces.tf
@@ -9,3 +9,9 @@ resource "kubernetes_namespace" "network" {
     name = "network"
   }
 }
+
+resource "kubernetes_namespace" "flux" {
+  metadata {
+    name = "flux"
+  }
+}

--- a/terraform/aws/modules/cluster-post-installation/output.tf
+++ b/terraform/aws/modules/cluster-post-installation/output.tf
@@ -1,0 +1,6 @@
+output "post_installation_message" {
+  value = <<EOF
+  Do not forget to run fluxctl identity and add the public key to Gitlab.
+  After the initial setup the Mattermost provisioner resources are managed by Flux and cannot be updated via Terrrform. 
+  EOF
+}

--- a/terraform/aws/modules/cluster-post-installation/provisioner-db.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner-db.tf
@@ -34,6 +34,13 @@ resource "aws_security_group" "cec_to_postgress" {
     Name    = "Cloud DB SG"
     Created = formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())
   }
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+
 }
 
 resource "aws_db_subnet_group" "subnets_db" {

--- a/terraform/aws/modules/cluster-post-installation/provisioner.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner.tf
@@ -202,6 +202,13 @@ resource "kubernetes_deployment" "mattermost_cloud_main" {
 
     revision_history_limit = 2
   }
+  
+  lifecycle {
+    ignore_changes = [
+      metadata,
+      spec,
+    ]
+  }
 
   depends_on = [
     aws_db_instance.provisioner,
@@ -399,6 +406,13 @@ resource "kubernetes_deployment" "mattermost_cloud_installations" {
     revision_history_limit = 2
   }
 
+  lifecycle {
+    ignore_changes = [
+      metadata,
+      spec,
+    ]
+  }
+
   depends_on = [
     aws_db_instance.provisioner,
     kubernetes_secret.mattermost_cloud_secret,
@@ -433,6 +447,13 @@ resource "kubernetes_ingress" "mattermost_cloud_ingress" {
     }
   }
 
+  lifecycle {
+    ignore_changes = [
+      metadata,
+      spec,
+    ]
+  }
+
   depends_on = [
     aws_db_instance.provisioner
   ]
@@ -456,6 +477,14 @@ resource "kubernetes_secret" "mattermost_cloud_secret" {
 
   type = "Opaque"
 
+  lifecycle {
+    ignore_changes = [
+      metadata,
+      data,
+      type,
+    ]
+  }
+
   depends_on = [
     aws_db_instance.provisioner
   ]
@@ -473,6 +502,14 @@ resource "kubernetes_secret" "mattermost_cloud_ssh_secret" {
   }
 
   type = "Opaque"
+
+  lifecycle {
+    ignore_changes = [
+      metadata,
+      data,
+      type,
+    ]
+  }
 
   depends_on = [
     aws_db_instance.provisioner
@@ -498,6 +535,13 @@ resource "kubernetes_service" "mattermost_cloud_service" {
     }
 
     type = "ClusterIP"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      metadata,
+      spec,
+    ]
   }
 
   depends_on = [

--- a/terraform/aws/modules/cluster-post-installation/variables.tf
+++ b/terraform/aws/modules/cluster-post-installation/variables.tf
@@ -71,3 +71,13 @@ variable "kibana_tls_crt" {}
 variable "kibana_tls_key" {}
 
 variable "provisioner_user" {}
+
+variable "git_url" {}
+
+variable "git_path" {}
+
+variable "git_user" {}
+
+variable "git_email" {}
+
+variable "ssh_known_hosts" {}


### PR DESCRIPTION
This PR covers:
- adding FLUX for provisioner updates
- adding ignore states for already deployed provisioner resources (updates to Provisioner resources should be done in the Gitlab repo)
- create output message to describe manual step needed after Flux deployment

