### PR TITLE
gitlab: add registry route53 registration

### DIFF
--- a/terraform/aws/modules/gitlab/chart_values.yaml
+++ b/terraform/aws/modules/gitlab/chart_values.yaml
@@ -84,18 +84,11 @@ certmanager:
 nginx-ingress:
   enabled: true
   controller:
-    scope:
-      enabled: false
-    replicaCount: 2
-    minAvailable: 1
     service:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
         service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
         service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
-  defaultBackend:
-    minAvailable: 1
-    replicaCount: 1
 gitlab-runner:
   install: true
   concurrent: 10

--- a/terraform/aws/modules/gitlab/chart_values.yaml
+++ b/terraform/aws/modules/gitlab/chart_values.yaml
@@ -84,11 +84,18 @@ certmanager:
 nginx-ingress:
   enabled: true
   controller:
+    scope:
+      enabled: false
+    replicaCount: 2
+    minAvailable: 1
     service:
       annotations:
         service.beta.kubernetes.io/aws-load-balancer-backend-protocol: https
         service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
         service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+  defaultBackend:
+    minAvailable: 1
+    replicaCount: 1
 gitlab-runner:
   install: true
   concurrent: 10

--- a/terraform/aws/modules/gitlab/gitlab-route53.tf
+++ b/terraform/aws/modules/gitlab/gitlab-route53.tf
@@ -13,9 +13,22 @@ resource "aws_route53_record" "gitlab_record" {
   name    = "gitlab"
   type    = "CNAME"
   ttl     = "60"
-  records = ["${data.kubernetes_service.gitlab_nginx.load_balancer_ingress.0.hostname}"]
+  records = [data.kubernetes_service.gitlab_nginx.load_balancer_ingress.0.hostname]
+
   depends_on = [
     helm_release.gitlab,
   ]
 }
 
+
+resource "aws_route53_record" "registry_record" {
+  zone_id = var.private_hosted_zoneid
+  name    = "registry"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [data.kubernetes_service.gitlab_nginx.load_balancer_ingress.0.hostname]
+
+  depends_on = [
+    helm_release.gitlab,
+  ]
+}

--- a/terraform/aws/modules/gitlab/gitlab.tf
+++ b/terraform/aws/modules/gitlab/gitlab.tf
@@ -76,7 +76,7 @@ resource "helm_release" "gitlab" {
     name  = "global.appConfig.backups.tmpBucket"
     value = var.gitlab_tmp_bucket
   }
-  
+
   set {
     name  = "global.smtp.address"
     value = var.smtp_address


### PR DESCRIPTION
#### Summary
- add the missing registry dns 


already applied in the environment 