### PR TITLE
Move lambda functions to use S3 for code source instead of local files

### DIFF
--- a/terraform/aws/modules/bind-server/bind-server-network-attachment.tf
+++ b/terraform/aws/modules/bind-server/bind-server-network-attachment.tf
@@ -51,7 +51,6 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole" {
 }
 
 resource "aws_lambda_function" "bind_server_network_attachment" {
-<<<<<<< HEAD
   s3_bucket        = "releases.mattermost.com"
   s3_key           = "mattermost-cloud/bind-server-network-attachment/master/main.zip"
   function_name = "bind-server-network-attachment"
@@ -59,15 +58,6 @@ resource "aws_lambda_function" "bind_server_network_attachment" {
   handler       = "main"
   timeout       = 120
   runtime = "go1.x"
-=======
-  filename         = "../../../../../bind-server-network-attachment/main.zip"
-  function_name    = "bind-server-network-attachment"
-  role             = aws_iam_role.bind_lambda_role.arn
-  handler          = "main"
-  timeout          = 120
-  source_code_hash = filebase64sha256("../../../../../bind-server-network-attachment/main.zip")
-  runtime          = "go1.x"
->>>>>>> master
   vpc_config {
     subnet_ids         = flatten([var.subnet_ids])
     security_group_ids = [aws_security_group.bind_lambda_sg.id]

--- a/terraform/aws/modules/bind-server/bind-server-network-attachment.tf
+++ b/terraform/aws/modules/bind-server/bind-server-network-attachment.tf
@@ -51,13 +51,13 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole" {
 }
 
 resource "aws_lambda_function" "bind_server_network_attachment" {
-  s3_bucket        = "releases.mattermost.com"
-  s3_key           = "mattermost-cloud/bind-server-network-attachment/master/main.zip"
+  s3_bucket     = "releases.mattermost.com"
+  s3_key        = "mattermost-cloud/bind-server-network-attachment/master/main.zip"
   function_name = "bind-server-network-attachment"
   role          = aws_iam_role.bind_lambda_role.arn
   handler       = "main"
   timeout       = 120
-  runtime = "go1.x"
+  runtime       = "go1.x"
   vpc_config {
     subnet_ids         = flatten([var.subnet_ids])
     security_group_ids = [aws_security_group.bind_lambda_sg.id]

--- a/terraform/aws/modules/bind-server/bind-server-network-attachment.tf
+++ b/terraform/aws/modules/bind-server/bind-server-network-attachment.tf
@@ -51,12 +51,12 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole" {
 }
 
 resource "aws_lambda_function" "bind_server_network_attachment" {
-  filename      = "../../../../../bind-server-network-attachment/main.zip"
+  s3_bucket        = "releases.mattermost.com"
+  s3_key           = "mattermost-cloud/bind-server-network-attachment/master/main.zip"
   function_name = "bind-server-network-attachment"
   role          = aws_iam_role.bind_lambda_role.arn
   handler       = "main"
   timeout       = 120
-  source_code_hash = filebase64sha256("../../../../../bind-server-network-attachment/main.zip")
   runtime = "go1.x"
   vpc_config {
     subnet_ids = flatten([var.subnet_ids])

--- a/terraform/aws/modules/cluster/cloud-server-auth.tf
+++ b/terraform/aws/modules/cluster/cloud-server-auth.tf
@@ -29,12 +29,12 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
 }
 
 resource "aws_lambda_function" "cloud_server_auth" {
-  filename         = "../../../../../../cloud-server-auth/cloud-server-auth.zip"
+  s3_bucket        = "releases.mattermost.com"
+  s3_key           = "mattermost-cloud/cloud-server-auth/master/cloud-server-auth.zip"
   function_name    = "cloud-server-auth"
   role             = aws_iam_role.auth_lambda_role.arn
   handler          = "cloud-server-auth"
   timeout          = 180
-  source_code_hash = filebase64sha256("../../../../../../cloud-server-auth/cloud-server-auth.zip")
   runtime          = "go1.x"
   vpc_config {
     subnet_ids         = flatten(var.auth_private_subnet_ids)

--- a/terraform/aws/modules/cluster/cloud-server-auth.tf
+++ b/terraform/aws/modules/cluster/cloud-server-auth.tf
@@ -29,13 +29,13 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRole" {
 }
 
 resource "aws_lambda_function" "cloud_server_auth" {
-  s3_bucket        = "releases.mattermost.com"
-  s3_key           = "mattermost-cloud/cloud-server-auth/master/cloud-server-auth.zip"
-  function_name    = "cloud-server-auth"
-  role             = aws_iam_role.auth_lambda_role.arn
-  handler          = "cloud-server-auth"
-  timeout          = 180
-  runtime          = "go1.x"
+  s3_bucket     = "releases.mattermost.com"
+  s3_key        = "mattermost-cloud/cloud-server-auth/master/cloud-server-auth.zip"
+  function_name = "cloud-server-auth"
+  role          = aws_iam_role.auth_lambda_role.arn
+  handler       = "cloud-server-auth"
+  timeout       = 180
+  runtime       = "go1.x"
   vpc_config {
     subnet_ids         = flatten(var.auth_private_subnet_ids)
     security_group_ids = [aws_security_group.auth_lambda_sg.id]

--- a/terraform/aws/modules/cluster/elb-cloudwatch-alarms.tf
+++ b/terraform/aws/modules/cluster/elb-cloudwatch-alarms.tf
@@ -47,13 +47,13 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole_alert" {
 }
 
 resource "aws_lambda_function" "alert_elb_cloudwatch_alarm" {
-  s3_bucket        = "releases.mattermost.com"
-  s3_key           = "mattermost-cloud/alert-elb-cloudwatch-alarm/master/main.zip"
-  function_name    = "receive-elb-cloudwatch-alarm"
-  role             = aws_iam_role.lambda_role_receive_elb_cloudwatch_alarm.arn
-  handler          = "main"
-  timeout          = 120
-  runtime          = "go1.x"
+  s3_bucket     = "releases.mattermost.com"
+  s3_key        = "mattermost-cloud/alert-elb-cloudwatch-alarm/master/main.zip"
+  function_name = "receive-elb-cloudwatch-alarm"
+  role          = aws_iam_role.lambda_role_receive_elb_cloudwatch_alarm.arn
+  handler       = "main"
+  timeout       = 120
+  runtime       = "go1.x"
 
   environment {
     variables = {
@@ -145,13 +145,13 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole_create" {
 }
 
 resource "aws_lambda_function" "create_elb_cloudwatch_alarm" {
-  s3_bucket        = "releases.mattermost.com"
-  s3_key           = "mattermost-cloud/create-elb-cloudwatch-alarm/master/main.zip"
-  function_name    = "create-elb-cloudwatch-alarm"
-  role             = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.arn
-  handler          = "main"
-  timeout          = 120
-  runtime          = "go1.x"
+  s3_bucket     = "releases.mattermost.com"
+  s3_key        = "mattermost-cloud/create-elb-cloudwatch-alarm/master/main.zip"
+  function_name = "create-elb-cloudwatch-alarm"
+  role          = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.arn
+  handler       = "main"
+  timeout       = 120
+  runtime       = "go1.x"
 
   environment {
     variables = {

--- a/terraform/aws/modules/cluster/elb-cloudwatch-alarms.tf
+++ b/terraform/aws/modules/cluster/elb-cloudwatch-alarms.tf
@@ -47,12 +47,12 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole_alert" {
 }
 
 resource "aws_lambda_function" "alert_elb_cloudwatch_alarm" {
-  filename         = "../../../../../../alert-elb-cloudwatch-alarm/main.zip"
+  s3_bucket        = "releases.mattermost.com"
+  s3_key           = "mattermost-cloud/alert-elb-cloudwatch-alarm/master/main.zip"
   function_name    = "receive-elb-cloudwatch-alarm"
   role             = aws_iam_role.lambda_role_receive_elb_cloudwatch_alarm.arn
   handler          = "main"
   timeout          = 120
-  source_code_hash = filebase64sha256("../../../../../../alert-elb-cloudwatch-alarm/main.zip")
   runtime          = "go1.x"
 
   environment {
@@ -145,12 +145,12 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole_create" {
 }
 
 resource "aws_lambda_function" "create_elb_cloudwatch_alarm" {
-  filename         = "../../../../../../create-elb-cloudwatch-alarm/main.zip"
+  s3_bucket        = "releases.mattermost.com"
+  s3_key           = "mattermost-cloud/create-elb-cloudwatch-alarm/master/main.zip"
   function_name    = "create-elb-cloudwatch-alarm"
   role             = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.arn
   handler          = "main"
   timeout          = 120
-  source_code_hash = filebase64sha256("../../../../../../create-elb-cloudwatch-alarm/main.zip")
   runtime          = "go1.x"
 
   environment {

--- a/terraform/aws/modules/cluster/grafana-aws-metrics.tf
+++ b/terraform/aws/modules/cluster/grafana-aws-metrics.tf
@@ -97,13 +97,13 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRoleGrafan
 }
 
 resource "aws_lambda_function" "grafana_aws_metrics" {
-  s3_bucket        = "releases.mattermost.com"
-  s3_key           = "mattermost-cloud/grafana-aws-metrics/master/main.zip"
-  function_name    = "grafana-aws-metrics"
-  role             = aws_iam_role.grafana_lambda_role.arn
-  handler          = "main"
-  timeout          = 120
-  runtime          = "go1.x"
+  s3_bucket     = "releases.mattermost.com"
+  s3_key        = "mattermost-cloud/grafana-aws-metrics/master/main.zip"
+  function_name = "grafana-aws-metrics"
+  role          = aws_iam_role.grafana_lambda_role.arn
+  handler       = "main"
+  timeout       = 120
+  runtime       = "go1.x"
   vpc_config {
     subnet_ids         = flatten(var.private_subnet_ids)
     security_group_ids = [aws_security_group.grafana_lambda_sg.id]

--- a/terraform/aws/modules/cluster/grafana-aws-metrics.tf
+++ b/terraform/aws/modules/cluster/grafana-aws-metrics.tf
@@ -97,12 +97,12 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaVPCAccessExecutionRoleGrafan
 }
 
 resource "aws_lambda_function" "grafana_aws_metrics" {
-  filename         = "../../../../../../grafana-aws-metrics/main.zip"
+  s3_bucket        = "releases.mattermost.com"
+  s3_key           = "mattermost-cloud/grafana-aws-metrics/master/main.zip"
   function_name    = "grafana-aws-metrics"
   role             = aws_iam_role.grafana_lambda_role.arn
   handler          = "main"
   timeout          = 120
-  source_code_hash = filebase64sha256("../../../../../../grafana-aws-metrics/main.zip")
   runtime          = "go1.x"
   vpc_config {
     subnet_ids         = flatten(var.private_subnet_ids)

--- a/terraform/aws/modules/cluster/prometheus-registration-service.tf
+++ b/terraform/aws/modules/cluster/prometheus-registration-service.tf
@@ -58,12 +58,12 @@ resource "aws_iam_role_policy_attachment" "AmazonRoute53ReadOnlyAccess" {
 
 
 resource "aws_lambda_function" "prometheus_registration" {
-  filename         = "../../../../../../prometheus-dns-registration-service/main.zip"
+  s3_bucket        = "releases.mattermost.com"
+  s3_key           = "mattermost-cloud/prometheus-dns-registration-service/master/main.zip"
   function_name    = "prometheus-dns-registration-service"
   role             = aws_iam_role.lambda_role.arn
   handler          = "main"
   timeout          = 120
-  source_code_hash = filebase64sha256("../../../../../../prometheus-dns-registration-service/main.zip")
   runtime          = "go1.x"
   vpc_config {
     subnet_ids         = flatten([var.private_subnet_ids])

--- a/terraform/aws/modules/cluster/prometheus-registration-service.tf
+++ b/terraform/aws/modules/cluster/prometheus-registration-service.tf
@@ -58,13 +58,13 @@ resource "aws_iam_role_policy_attachment" "AmazonRoute53ReadOnlyAccess" {
 
 
 resource "aws_lambda_function" "prometheus_registration" {
-  s3_bucket        = "releases.mattermost.com"
-  s3_key           = "mattermost-cloud/prometheus-dns-registration-service/master/main.zip"
-  function_name    = "prometheus-dns-registration-service"
-  role             = aws_iam_role.lambda_role.arn
-  handler          = "main"
-  timeout          = 120
-  runtime          = "go1.x"
+  s3_bucket     = "releases.mattermost.com"
+  s3_key        = "mattermost-cloud/prometheus-dns-registration-service/master/main.zip"
+  function_name = "prometheus-dns-registration-service"
+  role          = aws_iam_role.lambda_role.arn
+  handler       = "main"
+  timeout       = 120
+  runtime       = "go1.x"
   vpc_config {
     subnet_ids         = flatten([var.private_subnet_ids])
     security_group_ids = [aws_security_group.lambda-sg.id]

--- a/terraform/aws/modules/vpc-setup/vpc.tf
+++ b/terraform/aws/modules/vpc-setup/vpc.tf
@@ -8,7 +8,8 @@ resource "aws_vpc" "vpc_creation" {
     {
       "Name" = format("%s-%s", var.name, join("", split(".", split("/", each.value)[0]))),
       "Available" = "true",
-      "CloudClusterID" = "none"
+      "CloudClusterID" = "none",
+      "CloudClusterOwner" = "none",
       "Size" = split("/", each.value)[1]
     },
     var.tags
@@ -17,7 +18,8 @@ resource "aws_vpc" "vpc_creation" {
     ignore_changes = [
       # Ignore changes to tag Available
       tags["Available"],
-      tags["CloudClusterID"]
+      tags["CloudClusterID"],
+      tags["CloudClusterOwner"]
     ]
   }
 }

--- a/terraform/aws/modules/vpc-setup/vpc.tf
+++ b/terraform/aws/modules/vpc-setup/vpc.tf
@@ -6,11 +6,11 @@ resource "aws_vpc" "vpc_creation" {
   enable_dns_hostnames = var.enable_dns_hostnames
   tags = merge(
     {
-      "Name" = format("%s-%s", var.name, join("", split(".", split("/", each.value)[0]))),
-      "Available" = "true",
-      "CloudClusterID" = "none",
+      "Name"              = format("%s-%s", var.name, join("", split(".", split("/", each.value)[0]))),
+      "Available"         = "true",
+      "CloudClusterID"    = "none",
       "CloudClusterOwner" = "none",
-      "Size" = split("/", each.value)[1]
+      "Size"              = split("/", each.value)[1]
     },
     var.tags
   )


### PR DESCRIPTION
This PR
- Changes lambda function deployments to use remote S3 bucket instead of local zip files.
- Adds a lifecycle for a new tag we are using via the Provisioner

