### PR TITLE
add kms permissions on provisioner user

### DIFF
--- a/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/main.tf
@@ -59,6 +59,7 @@ module "cluster-post-installation" {
   flux_git_url                                 = var.flux_git_url
   validation_acm_zoneid                        = var.validation_acm_zoneid
   domain                                       = var.domain
+  cloud_vpn_cidr                               = var.cloud_vpn_cidr
 
   providers = {
     aws = aws.post-deployment

--- a/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/variables.tf
+++ b/terraform/aws/environments/prod/4-command-and-control/3-cluster-post-installation/variables.tf
@@ -182,3 +182,8 @@ variable "validation_acm_zoneid" {
   default     = ""
   description = "public zone id to create ACM certificate validations for private Route53 zones"
 }
+
+variable "cloud_vpn_cidr" {
+  type    = string
+  default = ""
+}

--- a/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/main.tf
+++ b/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/main.tf
@@ -59,6 +59,7 @@ module "cluster-post-installation" {
   flux_git_url                                 = var.flux_git_url
   validation_acm_zoneid                        = var.validation_acm_zoneid
   domain                                       = var.domain
+  cloud_vpn_cidr                               = var.cloud_vpn_cidr
 
   providers = {
     aws = aws.post-deployment

--- a/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/variables.tf
+++ b/terraform/aws/environments/staging/4-command-and-control/3-cluster-post-installation/variables.tf
@@ -203,3 +203,8 @@ variable "validation_acm_zoneid" {
   default     = ""
   description = "public zone id to create ACM certificate validations for private Route53 zones"
 }
+
+variable "cloud_vpn_cidr" {
+  type    = string
+  default = ""
+}

--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -338,6 +338,33 @@ resource "aws_iam_policy" "iam" {
 EOF
 }
 
+resource "aws_iam_policy" "kms" {
+  name        = "mattermost-provisioner-kms-policy"
+  path        = "/"
+  description = "KMS permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "kms0",
+            "Effect": "Allow",
+            "Action": [
+                "kms:CreateKey",
+                "kms:Describe*",
+                "kms:List*",
+                "kms:Get*",
+                "kms:ScheduleKeyDeletion",
+                "kms:CreateAlias"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
 resource "aws_iam_user_policy_attachment" "attach_route53" {
   user       = var.provisioner_user
   policy_arn = aws_iam_policy.route53.arn
@@ -371,4 +398,9 @@ resource "aws_iam_user_policy_attachment" "attach_vpc" {
 resource "aws_iam_user_policy_attachment" "attach_iam" {
   user       = var.provisioner_user
   policy_arn = aws_iam_policy.iam.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_kms" {
+  user       = var.provisioner_user
+  policy_arn = aws_iam_policy.kms.arn
 }


### PR DESCRIPTION
#### Summary

- Adding KMS permissions on provisioner user
- Fix `cloud_vpn_cidr` variable that was missing

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24215

