### PR TITLE
[MM 24511] Updating SGs in all modules to allow 3022 port for Teleport access

### DIFF
--- a/terraform/aws/modules/bind-server/bind-servers.tf
+++ b/terraform/aws/modules/bind-server/bind-servers.tf
@@ -25,6 +25,13 @@ resource "aws_security_group" "bind_sg" {
     cidr_blocks = var.vpn_cidr
   }
 
+  ingress {
+    from_port   = 3022
+    to_port     = 3022
+    protocol    = "tcp"
+    cidr_blocks = var.teleport_cidr
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/aws/modules/bind-server/variables.tf
+++ b/terraform/aws/modules/bind-server/variables.tf
@@ -39,3 +39,5 @@ variable "cidr_blocks" {}
 variable "environment" {}
 
 variable "ssh_key_public" {}
+
+variable "teleport_cidr" {}

--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -356,7 +356,8 @@ resource "aws_iam_policy" "kms" {
                 "kms:List*",
                 "kms:Get*",
                 "kms:ScheduleKeyDeletion",
-                "kms:CreateAlias"
+                "kms:CreateAlias",
+                "kms:TagResource"
             ],
             "Resource": "*"
         }

--- a/terraform/aws/modules/cluster/master_sg.tf
+++ b/terraform/aws/modules/cluster/master_sg.tf
@@ -11,7 +11,7 @@ resource "aws_security_group" "cluster-sg" {
     protocol    = "tcp"
     cidr_blocks = var.teleport_cidr
   }
-  
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/aws/modules/cluster/master_sg.tf
+++ b/terraform/aws/modules/cluster/master_sg.tf
@@ -5,6 +5,13 @@ resource "aws_security_group" "cluster-sg" {
   description = "Cluster communication with worker nodes"
   vpc_id      = var.vpc_id
 
+  ingress {
+    from_port   = 3022
+    to_port     = 3022
+    protocol    = "tcp"
+    cidr_blocks = var.teleport_cidr
+  }
+  
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/aws/modules/cluster/variables.tf
+++ b/terraform/aws/modules/cluster/variables.tf
@@ -47,3 +47,5 @@ variable "key_name" {}
 variable "opsgenie_apikey" {}
 
 variable "opsgenie_scheduler_team" {}
+
+variable "teleport_cidr" {}

--- a/terraform/aws/modules/cluster/worker_sg.tf
+++ b/terraform/aws/modules/cluster/worker_sg.tf
@@ -4,6 +4,13 @@ resource "aws_security_group" "worker-sg" {
   description = "Security group for all workers in the cluster"
   vpc_id      = var.vpc_id
 
+  ingress {
+    from_port   = 3022
+    to_port     = 3022
+    protocol    = "tcp"
+    cidr_blocks = var.teleport_cidr
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/aws/modules/eks-cluster/master_sg.tf
+++ b/terraform/aws/modules/eks-cluster/master_sg.tf
@@ -5,6 +5,13 @@ resource "aws_security_group" "cluster-sg" {
   description = "Cluster communication with worker nodes"
   vpc_id      = var.vpc_id
 
+  ingress {
+    from_port   = 3022
+    to_port     = 3022
+    protocol    = "tcp"
+    cidr_blocks = var.teleport_cidr
+  }
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/aws/modules/eks-cluster/variables.tf
+++ b/terraform/aws/modules/eks-cluster/variables.tf
@@ -27,3 +27,5 @@ variable "region" {}
 variable "eks_ami_id" {}
 
 variable "key_name" {}
+
+variable "teleport_cidr" {}

--- a/terraform/aws/modules/eks-cluster/worker_sg.tf
+++ b/terraform/aws/modules/eks-cluster/worker_sg.tf
@@ -10,7 +10,7 @@ resource "aws_security_group" "worker-sg" {
     protocol    = "tcp"
     cidr_blocks = var.teleport_cidr
   }
-  
+
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/aws/modules/eks-cluster/worker_sg.tf
+++ b/terraform/aws/modules/eks-cluster/worker_sg.tf
@@ -4,6 +4,13 @@ resource "aws_security_group" "worker-sg" {
   description = "Security group for all workers in the cluster"
   vpc_id      = var.vpc_id
 
+  ingress {
+    from_port   = 3022
+    to_port     = 3022
+    protocol    = "tcp"
+    cidr_blocks = var.teleport_cidr
+  }
+  
   egress {
     from_port   = 0
     to_port     = 0

--- a/terraform/aws/modules/subnet-and-networking/security_groups.tf
+++ b/terraform/aws/modules/subnet-and-networking/security_groups.tf
@@ -4,6 +4,14 @@ resource "aws_security_group" "master_sg" {
   name        = format("%s-%s-master-sg", var.name, join("", split(".", split("/", each.value)[0])))
   description = "Master Nodes Security Group"
   vpc_id      = data.aws_vpc.vpc_ids[each.value]["id"]
+
+  ingress {
+    from_port   = 3022
+    to_port     = 3022
+    protocol    = "tcp"
+    cidr_blocks = var.teleport_cidr
+  }
+
   tags = merge(
     {
       "Name"     = format("%s-%s-master-sg", var.name, join("", split(".", split("/", each.value)[0]))),
@@ -19,6 +27,14 @@ resource "aws_security_group" "worker_sg" {
   name        = format("%s-%s-worker-sg", var.name, join("", split(".", split("/", each.value)[0])))
   description = "Worker Nodes Security Group"
   vpc_id      = data.aws_vpc.vpc_ids[each.value]["id"]
+
+  ingress {
+    from_port   = 3022
+    to_port     = 3022
+    protocol    = "tcp"
+    cidr_blocks = var.teleport_cidr
+  }
+
   tags = merge(
     {
       "Name"     = format("%s-%s-worker-sg", var.name, join("", split(".", split("/", each.value)[0]))),

--- a/terraform/aws/modules/subnet-and-networking/variables.tf
+++ b/terraform/aws/modules/subnet-and-networking/variables.tf
@@ -13,3 +13,6 @@ variable "transit_gtw_route_destination" {}
 variable "environment" {}
 
 variable "region" {}
+
+variable "teleport_cidr" {}
+


### PR DESCRIPTION
#### Summary
Add Teleport SSH access to all SGs

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24511 

#### Description
This PR:

- Adds the 3022 port in all SGs of the Terraform modules
  - The CIDR is parameterised 
- It adds kms:TagResource permission to the Cloud Provisioner

