### PR TITLE
MM-24541: added IAM provisioner permissions for accessing sts:GetCallerIdentity

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -369,7 +369,7 @@ EOF
 resource "aws_iam_policy" "tag" {
   name        = "mattermost-provisioner-tag-policy"
   path        = "/"
-  description = "Resource Group Tagging permissions for provisioner user"
+  description = "Resource Groups Tagging permissions for provisioner user"
 
   policy = <<EOF
 {
@@ -382,6 +382,28 @@ resource "aws_iam_policy" "tag" {
                 "tag:GetResources",
                 "tag:GetTagKeys",
                 "tag:GetTagValues"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "sts" {
+  name        = "mattermost-provisioner-sts-policy"
+  path        = "/"
+  description = "Security Token Service permissions for provisioner user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "sts0",
+            "Effect": "Allow",
+            "Action": [
+                "sts:GetCallerIdentity",
             ],
             "Resource": "*"
         }

--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -456,3 +456,8 @@ resource "aws_iam_user_policy_attachment" "attach_kms" {
   user       = var.provisioner_user
   policy_arn = aws_iam_policy.kms.arn
 }
+
+resource "aws_sts_user_policy_attachment" "attach_sts" {
+  user       = var.provisioner_user
+  policy_sts = aws_iam_policy.sts.arn
+}


### PR DESCRIPTION
#### Summary
This PR adds provisioner permissions for accessing sts:GetCallerIdentity.

#### Ticket Link
Fix: https://mattermost.atlassian.net/browse/MM-24541
Unblock: https://github.com/mattermost/mattermost-cloud/pull/208

