### PR TITLE
Updating provisioner users to handle list of users

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -391,46 +391,55 @@ EOF
 }
 
 resource "aws_iam_user_policy_attachment" "attach_tag" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.tag.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_route53" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.route53.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_rds" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.rds.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_s3" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.s3.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_secrets_manager" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.secrets_manager.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_ec2" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.ec2.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_vpc" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.vpc.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_iam" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.iam.arn
 }
 
 resource "aws_iam_user_policy_attachment" "attach_kms" {
-  user       = var.provisioner_user
+  for_each   = toset(var.provisioner_users)
+  user       = each.value
   policy_arn = aws_iam_policy.kms.arn
 }

--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -356,7 +356,8 @@ resource "aws_iam_policy" "kms" {
                 "kms:List*",
                 "kms:Get*",
                 "kms:ScheduleKeyDeletion",
-                "kms:CreateAlias"
+                "kms:CreateAlias",
+                "kms:TagResource"
             ],
             "Resource": "*"
         }

--- a/terraform/aws/modules/cluster-post-installation/variables.tf
+++ b/terraform/aws/modules/cluster-post-installation/variables.tf
@@ -58,7 +58,7 @@ variable "mattermost_cloud_secrets_keep_filestore_data" {}
 
 variable "mattermost_cloud_secrets_keep_database_data" {}
 
-variable "provisioner_user" {}
+variable "provisioner_users" {}
 
 variable "git_url" {}
 


### PR DESCRIPTION
#### Summary
Updating provisioner users to handle list of users

#### Ticket Link
This PR updates the Post Installation TF module and specifically the Provisioner user permissions to be able to handle a list of users. Now a list of user names can be passes and they will all get the provisioner permissions.