### PR TITLE
MM-23151: added permission for tagging secrets

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/cluster-post-installation/provisioner_user_permissions.tf
@@ -145,6 +145,7 @@ resource "aws_iam_policy" "secrets_manager" {
             "Sid": "secrets0",
             "Effect": "Allow",
             "Action": [
+                "secretsmanager:TagResource",
                 "secretsmanager:CreateSecret",
                 "secretsmanager:DeleteSecret",
                 "secretsmanager:GetSecretValue"


### PR DESCRIPTION
#### Summary
This PR grants permissions to the provisioner's IAM in order to allow tagging secrets created with the secrets manager service. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-23151
https://github.com/mattermost/mattermost-cloud/pull/209

Signed-off-by: Gabriel Linden Sagula <gsagula@gmail.com>
