### PR TITLE
[MM-24711] Enabling 16000 Max connections for RDS Aurora Clusters

### DIFF
--- a/terraform/aws/modules/subnet-and-networking/provisioner_db_parameter_group.tf
+++ b/terraform/aws/modules/subnet-and-networking/provisioner_db_parameter_group.tf
@@ -27,7 +27,7 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group" {
     name         = "binlog_format"
     value        = "MIXED"
   }
-  
+
   parameter {
     apply_method = "immediate"
     name         = "max_connections"

--- a/terraform/aws/modules/subnet-and-networking/provisioner_db_parameter_group.tf
+++ b/terraform/aws/modules/subnet-and-networking/provisioner_db_parameter_group.tf
@@ -3,6 +3,12 @@ resource "aws_db_parameter_group" "db_parameter_group" {
   name   = "mattermost-provisioner-rds-pg"
   family = "aurora-mysql5.7"
 
+  parameter {
+    apply_method = "immediate"
+    name         = "max_connections"
+    value        = 16000
+  }
+
   tags = merge(
     {
       "MattermostCloudInstallationDatabase" = "MYSQL/Aurora"
@@ -21,6 +27,13 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group" {
     name         = "binlog_format"
     value        = "MIXED"
   }
+  
+  parameter {
+    apply_method = "immediate"
+    name         = "max_connections"
+    value        = 16000
+  }
+
   tags = merge(
     {
       "MattermostCloudInstallationDatabase" = "MYSQL/Aurora"


### PR DESCRIPTION
#### Summary
With this PR:
- The default Max available connections to RDS Aurora Clusters is increased to 16000.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24771

