### PR TITLE
move vpc flow logs to security account s3 buckets

### DIFF
--- a/terraform/aws/modules/security/variables.tf
+++ b/terraform/aws/modules/security/variables.tf
@@ -1,1 +1,6 @@
 variable "environment" {}
+
+variable "enable_flow_logs" {
+  default = true
+  type    = bool
+}

--- a/terraform/aws/modules/security/vpc_flow_logs.tf
+++ b/terraform/aws/modules/security/vpc_flow_logs.tf
@@ -5,23 +5,10 @@ data "aws_kms_alias" "s3" {
 }
 
 resource "aws_flow_log" "cloud_vpc" {
-  count                = length(data.aws_vpcs.vpcs.ids)
-  log_destination      = aws_s3_bucket.vpc_flow_logs.arn
+  count                = var.enable_flow_logs ? length(data.aws_vpcs.vpcs.ids) : 0
+  log_destination      = "arn:aws:s3:::mm-cloud-flowlogs-${var.environment}"
   log_destination_type = "s3"
   traffic_type         = "ALL"
   vpc_id               = element(data.aws_vpcs.vpcs.ids[*], count.index)
 }
 
-resource "aws_s3_bucket" "vpc_flow_logs" {
-  bucket = "mattermost-vpc-flow-logs-${var.environment}"
-  region = "us-east-1"
-  acl    = "private"
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = data.aws_kms_alias.s3.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
-}


### PR DESCRIPTION
#### Summary

- Change location of VPC flow logs to be stored in Security account S3 buckets
- making conditional if we want flow logs or not
