### PR TITLE
[MM-25291] Additional account quota metrics, Cloudwatch alerts and Grafana dashboard.

### DIFF
--- a/lambda-functions/grafana-aws-metrics/Gopkg.lock
+++ b/lambda-functions/grafana-aws-metrics/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:f72cb64e41191cfd2298306e1966b494ed0a66cd3b709025a4e662727016fe7e"
+  digest = "1:d92a0c10fb57de8742c33500c2fd96bd202fcafd14cb247d5185578f86b276fb"
   name = "github.com/aws/aws-lambda-go"
   packages = [
     "lambda",
@@ -11,11 +11,11 @@
     "lambdacontext",
   ]
   pruneopts = "UT"
-  revision = "e5086e5a7e53f7039034fa29008221760b04ff79"
-  version = "v1.13.2"
+  revision = "18b606949c45bc923e421d7ea891d6d02a34f7dd"
+  version = "v1.16.0"
 
 [[projects]]
-  digest = "1:3ea1748d5d74d279425c79b6328060e2f99c97eb89227d8157633ee61fab4a2b"
+  digest = "1:d9675649a9ffe9f4ff4b66e660afbddb24c4b4c032d7d5ac18cc6e65ec802933"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -37,6 +37,7 @@
     "aws/session",
     "aws/signer/v4",
     "internal/ini",
+    "internal/s3err",
     "internal/sdkio",
     "internal/sdkmath",
     "internal/sdkrand",
@@ -44,14 +45,23 @@
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/ec2query",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
     "private/protocol/json/jsonutil",
+    "private/protocol/jsonrpc",
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
+    "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
+    "service/autoscaling",
     "service/cloudwatch",
     "service/ec2",
     "service/elb",
+    "service/elbv2",
+    "service/rds",
+    "service/s3",
+    "service/servicequotas",
     "service/sts",
     "service/sts/stsiface",
   ]
@@ -148,9 +158,14 @@
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
     "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/autoscaling",
     "github.com/aws/aws-sdk-go/service/cloudwatch",
     "github.com/aws/aws-sdk-go/service/ec2",
     "github.com/aws/aws-sdk-go/service/elb",
+    "github.com/aws/aws-sdk-go/service/elbv2",
+    "github.com/aws/aws-sdk-go/service/rds",
+    "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/aws/aws-sdk-go/service/servicequotas",
     "github.com/aws/aws-sdk-go/service/sts",
     "github.com/aws/aws-sdk-go/service/sts/stsiface",
     "github.com/pkg/errors",

--- a/terraform/aws/modules/cluster-post-installation/grafana.tf
+++ b/terraform/aws/modules/cluster-post-installation/grafana.tf
@@ -15,6 +15,7 @@ resource "helm_release" "grafana" {
     kubernetes_config_map.account_view,
     kubernetes_config_map.cluster_view,
     kubernetes_config_map.installation_view,
-    kubernetes_config_map.alerting
+    kubernetes_config_map.alerting,
+    kubernetes_config_map.account_monitoring
   ]
 }

--- a/terraform/aws/modules/cluster-post-installation/grafana_dashboard_configmaps.tf
+++ b/terraform/aws/modules/cluster-post-installation/grafana_dashboard_configmaps.tf
@@ -70,4 +70,16 @@ resource "kubernetes_config_map" "uptime" {
   }
 }
 
+resource "kubernetes_config_map" "account_monitoring" {
+  metadata {
+    name      = "accountmonitoring-dashboard"
+    namespace = "monitoring"
+    labels = {
+      cloud_dashboards = "account_monitoring"
+    }
+  }
 
+  data = {
+    "acoount_monitoring.json" = "${file("../../../../grafana-dashboards/account_monitoring.json")}"
+  }
+}

--- a/terraform/aws/modules/cluster/grafana-aws-metrics.tf
+++ b/terraform/aws/modules/cluster/grafana-aws-metrics.tf
@@ -31,7 +31,11 @@ resource "aws_iam_role_policy" "grafana_metrics_lambda_policy" {
             "elasticloadbalancing:DescribeAccountLimits",
             "elasticloadbalancing:DescribeLoadBalancers",
             "cloudwatch:PutMetricData",
-            "ec2:DescribeVpcs"
+            "ec2:DescribeVpcs",
+            "rds:DescribeAccountAttributes",
+            "servicequotas:GetServiceQuota",
+            "autoscaling:DescribeAccountLimits",
+            "ec2:DescribeAddresses"
         ],
       "Effect": "Allow",
       "Resource": "*"

--- a/terraform/aws/modules/quota-alarms/main.tf
+++ b/terraform/aws/modules/quota-alarms/main.tf
@@ -4,16 +4,16 @@ data "aws_caller_identity" "current" {}
 resource "aws_cloudwatch_metric_alarm" "grafana_metrics" {
   for_each = toset(var.metrics)
 
-  alarm_name                = "${each.value}-quota-alarm"
-  comparison_operator       = "GreaterThanOrEqualToThreshold"
-  evaluation_periods        = "1"
-  metric_name               = each.value
-  namespace                 = "AWS/Grafana"
-  period                    = "3600"
-  statistic                 = "Average"
-  threshold                 = var.alarm_threshold
-  alarm_description         = "This metric monitors ${each.value} utilization"
-  actions_enabled           = "true"
-  alarm_actions             = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
-  ok_actions                = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
+  alarm_name          = "${each.value}-quota-alarm"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = each.value
+  namespace           = "AWS/Grafana"
+  period              = "3600"
+  statistic           = "Average"
+  threshold           = var.alarm_threshold
+  alarm_description   = "This metric monitors ${each.value} utilization"
+  actions_enabled     = "true"
+  alarm_actions       = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
+  ok_actions          = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
 }

--- a/terraform/aws/modules/quota-alarms/main.tf
+++ b/terraform/aws/modules/quota-alarms/main.tf
@@ -1,0 +1,19 @@
+
+data "aws_caller_identity" "current" {}
+
+resource "aws_cloudwatch_metric_alarm" "grafana_metrics" {
+  for_each = toset(var.metrics)
+
+  alarm_name                = "${each.value}-quota-alarm"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  evaluation_periods        = "1"
+  metric_name               = each.value
+  namespace                 = "AWS/Grafana"
+  period                    = "3600"
+  statistic                 = "Average"
+  threshold                 = var.alarm_threshold
+  alarm_description         = "This metric monitors ${each.value} utilization"
+  actions_enabled           = "true"
+  alarm_actions             = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
+  ok_actions                = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
+}

--- a/terraform/aws/modules/quota-alarms/variables.tf
+++ b/terraform/aws/modules/quota-alarms/variables.tf
@@ -1,0 +1,3 @@
+variable "metrics" {}
+
+variable "alarm_threshold" {}


### PR DESCRIPTION
#### Summary
With this PR:
- Additional account quota metrics are created for RDS, S3, Load Balancer, Auto Scaling and VPC services (Grafana Metrics Lambda)
- New Grafana dashboard is created to monitor quota utilization.
- New Cloudwatch Alerts are created with TF that integrate with Mattermost and Opsgenie when quota utilization reaches a specified value.
- Additional permissions are added in the Lambda role to support new metrics.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25291

