### PR TITLE
Adding SG rule to allow private subnets of C&C VPC to access the RDS databases to create tables

### DIFF
--- a/terraform/aws/modules/subnet-and-networking-3az/security_groups.tf
+++ b/terraform/aws/modules/subnet-and-networking-3az/security_groups.tf
@@ -141,3 +141,15 @@ resource "aws_security_group_rule" "db_ingress_worker" {
   to_port                  = 3306
   type                     = "ingress"
 }
+
+resource "aws_security_group_rule" "db_ingress_worker_command_control" {
+  for_each = toset(var.vpc_cidrs)
+
+  cidr_blocks              = var.command_and_control_private_subnet_cidrs
+  description              = "Ingress Traffic from Command and Control Private Subnets"
+  from_port                = 3306
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.db_sg[each.value]["id"]
+  to_port                  = 3306
+  type                     = "ingress"
+}

--- a/terraform/aws/modules/subnet-and-networking-3az/security_groups.tf
+++ b/terraform/aws/modules/subnet-and-networking-3az/security_groups.tf
@@ -145,11 +145,11 @@ resource "aws_security_group_rule" "db_ingress_worker" {
 resource "aws_security_group_rule" "db_ingress_worker_command_control" {
   for_each = toset(var.vpc_cidrs)
 
-  cidr_blocks              = var.command_and_control_private_subnet_cidrs
-  description              = "Ingress Traffic from Command and Control Private Subnets"
-  from_port                = 3306
-  protocol                 = "TCP"
-  security_group_id        = aws_security_group.db_sg[each.value]["id"]
-  to_port                  = 3306
-  type                     = "ingress"
+  cidr_blocks       = var.command_and_control_private_subnet_cidrs
+  description       = "Ingress Traffic from Command and Control Private Subnets"
+  from_port         = 3306
+  protocol          = "TCP"
+  security_group_id = aws_security_group.db_sg[each.value]["id"]
+  to_port           = 3306
+  type              = "ingress"
 }

--- a/terraform/aws/modules/subnet-and-networking-3az/variables.tf
+++ b/terraform/aws/modules/subnet-and-networking-3az/variables.tf
@@ -16,3 +16,4 @@ variable "region" {}
 
 variable "teleport_cidr" {}
 
+variable "command_and_control_private_subnet_cidrs" {}

--- a/terraform/aws/modules/subnet-and-networking/security_groups.tf
+++ b/terraform/aws/modules/subnet-and-networking/security_groups.tf
@@ -141,3 +141,15 @@ resource "aws_security_group_rule" "db_ingress_worker" {
   to_port                  = 3306
   type                     = "ingress"
 }
+
+resource "aws_security_group_rule" "db_ingress_worker_command_control" {
+  for_each = toset(var.vpc_cidrs)
+
+  cidr_blocks              = var.command_and_control_private_subnet_cidrs
+  description              = "Ingress Traffic from Command and Control Private Subnets"
+  from_port                = 3306
+  protocol                 = "TCP"
+  security_group_id        = aws_security_group.db_sg[each.value]["id"]
+  to_port                  = 3306
+  type                     = "ingress"
+}

--- a/terraform/aws/modules/subnet-and-networking/security_groups.tf
+++ b/terraform/aws/modules/subnet-and-networking/security_groups.tf
@@ -145,11 +145,11 @@ resource "aws_security_group_rule" "db_ingress_worker" {
 resource "aws_security_group_rule" "db_ingress_worker_command_control" {
   for_each = toset(var.vpc_cidrs)
 
-  cidr_blocks              = var.command_and_control_private_subnet_cidrs
-  description              = "Ingress Traffic from Command and Control Private Subnets"
-  from_port                = 3306
-  protocol                 = "TCP"
-  security_group_id        = aws_security_group.db_sg[each.value]["id"]
-  to_port                  = 3306
-  type                     = "ingress"
+  cidr_blocks       = var.command_and_control_private_subnet_cidrs
+  description       = "Ingress Traffic from Command and Control Private Subnets"
+  from_port         = 3306
+  protocol          = "TCP"
+  security_group_id = aws_security_group.db_sg[each.value]["id"]
+  to_port           = 3306
+  type              = "ingress"
 }

--- a/terraform/aws/modules/subnet-and-networking/variables.tf
+++ b/terraform/aws/modules/subnet-and-networking/variables.tf
@@ -16,3 +16,4 @@ variable "region" {}
 
 variable "teleport_cidr" {}
 
+variable "command_and_control_private_subnet_cidrs" {}


### PR DESCRIPTION
#### Summary
Adding SG rule to allow private subnets of C&C VPC to access the RDS Provisioning databases to create tables
