### PR TITLE
Reducing database factory replicas to 1 to avoid local terraform file inconsistency

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/database-factory.tf
+++ b/terraform/aws/modules/cluster-post-installation/database-factory.tf
@@ -10,7 +10,7 @@ resource "kubernetes_deployment" "mattermost_cloud_database_factory" {
   }
 
   spec {
-    replicas = 2
+    replicas = 1
 
     selector {
       match_labels = {


### PR DESCRIPTION
#### Summary
Reducing database factory replicas to 1 to avoid local terraform file inconsistency

