### PR TITLE
MM-25242 Pushing chartmuseum configuration and Gitlab cluster fixes

### DIFF
--- a/terraform/aws/modules/atlantis/nginx_internal_values.yaml
+++ b/terraform/aws/modules/atlantis/nginx_internal_values.yaml
@@ -3,9 +3,9 @@ controller:
   name: controller
   image:
     repository: quay.io/kubernetes-ingress-controller/nginx-ingress-controller
-    tag: "0.25.1"
+    tag: "0.31.1"
     pullPolicy: IfNotPresent
-    runAsUser: 33
+    runAsUser: 101
     allowPrivilegeEscalation: true
 
   # Configures the ports the nginx-controller listens on
@@ -56,7 +56,7 @@ controller:
     annotations:
       service.beta.kubernetes.io/aws-load-balancer-backend-protocol: tcp
       service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
-      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+      service.beta.kubernetes.io/aws-load-balancer-ssl-ports: 443
     labels: {}
     omitClusterIP: false
     clusterIP: ""

--- a/terraform/aws/modules/chartmuseum/chart_values.yaml
+++ b/terraform/aws/modules/chartmuseum/chart_values.yaml
@@ -1,0 +1,30 @@
+replicaCount: 1
+strategy:
+  type: RollingUpdate
+  rollingUpdate:
+    maxUnavailable: 0
+image:
+  repository: chartmuseum/chartmuseum
+  tag: v0.12.0
+  pullPolicy: IfNotPresent
+env:
+  open:
+    DISABLE_API: false
+    STORAGE: amazon
+    STORAGE_AMAZON_BUCKET: 
+    STORAGE_AMAZON_PREFIX:
+    STORAGE_AMAZON_REGION: us-east-1
+  secret:
+    AWS_ACCESS_KEY_ID: "" ## aws access key id value
+    AWS_SECRET_ACCESS_KEY: "" ## aws access key secret value
+
+## Ingress for load balancer
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx-internal
+    kubernetes.io/ingress.provider: nginx
+  hosts:
+    - name: 
+      path: /
+      tls: true 

--- a/terraform/aws/modules/chartmuseum/chartmuseum-route53.tf
+++ b/terraform/aws/modules/chartmuseum/chartmuseum-route53.tf
@@ -1,0 +1,21 @@
+data "kubernetes_service" "internal_nginx" {
+  metadata {
+    name      = "internal-nginx-ingress-controller"
+    namespace = "nginx-internal"
+  }
+  depends_on = [
+    helm_release.chartmuseum,
+  ]
+}
+
+resource "aws_route53_record" "chartmuseum" {
+  zone_id = var.private_hosted_zoneid
+  name    = "chartmuseum"
+  type    = "CNAME"
+  ttl     = "60"
+  records = [data.kubernetes_service.internal_nginx.load_balancer_ingress.0.hostname]
+
+  depends_on = [
+    helm_release.chartmuseum
+  ]
+}

--- a/terraform/aws/modules/chartmuseum/chartmuseum.tf
+++ b/terraform/aws/modules/chartmuseum/chartmuseum.tf
@@ -1,0 +1,42 @@
+resource "kubernetes_namespace" "chartmuseum" {
+  metadata {
+    name = "chartmuseum"
+  }
+}
+
+resource "helm_release" "chartmuseum" {
+  name      = "chartmuseum"
+  chart     = "stable/chartmuseum"
+  namespace = "chartmuseum"
+  values = [
+    "${file(var.chartmuseum_chart_values_directory)}"
+  ]
+
+  set {
+    name  = "env.open.STORAGE_AMAZON_BUCKET"
+    value = var.chartmuseum_bucket
+  }
+
+  set {
+    name  = "env.secret.AWS_ACCESS_KEY_ID"
+    value = var.chartmuseum_user_key_id
+  }
+
+  set {
+    name  = "env.secret.AWS_SECRET_ACCESS_KEY"
+    value = var.chartmuseum_user_access_key
+  }
+
+  set {
+    name  = "ingress.hosts[0].name"
+    value = var.chartmuseum_hostname
+  }
+
+
+  depends_on = [
+    kubernetes_namespace.chartmuseum,
+  ]
+
+  timeout = 1200
+
+}

--- a/terraform/aws/modules/chartmuseum/providers.tf
+++ b/terraform/aws/modules/chartmuseum/providers.tf
@@ -1,0 +1,31 @@
+data "helm_repository" "stable" {
+  name = "stable"
+  url  = "https://kubernetes-charts.storage.googleapis.com"
+}
+
+
+data "aws_eks_cluster_auth" "cluster_auth" {
+  name = var.deployment_name
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = var.deployment_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster_auth.token
+  load_config_file       = false
+  config_path            = "${var.kubeconfig_dir}/kubeconfig"
+}
+
+provider "helm" {
+  kubernetes {
+    config_path            = "${var.kubeconfig_dir}/kubeconfig"
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster_auth.token
+    load_config_file       = false
+  }
+}

--- a/terraform/aws/modules/chartmuseum/variables.tf
+++ b/terraform/aws/modules/chartmuseum/variables.tf
@@ -1,0 +1,15 @@
+variable "chartmuseum_chart_values_directory" {}
+
+variable "chartmuseum_bucket" {}
+
+variable "chartmuseum_user_key_id" {}
+
+variable "chartmuseum_user_access_key" {}
+
+variable "chartmuseum_hostname" {}
+
+variable "private_hosted_zoneid" {}
+
+variable "deployment_name" {}
+
+variable "kubeconfig_dir" {}

--- a/terraform/aws/modules/cluster/variables.tf
+++ b/terraform/aws/modules/cluster/variables.tf
@@ -27,4 +27,3 @@ variable "eks_ami_id" {}
 variable "key_name" {}
 
 variable "teleport_cidr" {}
-

--- a/terraform/aws/modules/eks-cluster/variables.tf
+++ b/terraform/aws/modules/eks-cluster/variables.tf
@@ -29,3 +29,5 @@ variable "eks_ami_id" {}
 variable "key_name" {}
 
 variable "teleport_cidr" {}
+
+variable "worker_private_subnet_ids" {}

--- a/terraform/aws/modules/eks-cluster/worker_asg.tf
+++ b/terraform/aws/modules/eks-cluster/worker_asg.tf
@@ -33,7 +33,7 @@ resource "aws_autoscaling_group" "worker-asg" {
   max_size             = var.max_size
   min_size             = var.min_size
   name                 = "${var.deployment_name}-worker-asg"
-  vpc_zone_identifier  = flatten(var.private_subnet_ids)
+  vpc_zone_identifier  = flatten(var.worker_private_subnet_ids)
   termination_policies = ["OldestLaunchConfiguration"]
 
   tag {


### PR DESCRIPTION
#### Summary
This PR:

- Adds the Chartmuseum module that deploys and configures Chartmuseum
- Adds a separate variable for the worker private subnets to solve the Gitlab issues in zone us-east-1d

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25242

