### PR TITLE
Adding cloudwatch permissions to get tags and delete alarms for Database factory user

### DIFF
--- a/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
+++ b/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
@@ -224,7 +224,9 @@ resource "aws_iam_policy" "autoscaling_db_factory" {
                 "application-autoscaling:DescribeScalingPolicies",
                 "application-autoscaling:DeleteScalingPolicy",
                 "cloudwatch:DescribeAlarms",
-                "cloudwatch:PutMetricAlarm"
+                "cloudwatch:PutMetricAlarm",
+                "cloudwatch:ListTagsForResource",
+                "cloudwatch:DeleteAlarms"
             ],
             "Resource": "*"
         }


### PR DESCRIPTION
#### Summary

Add cloudwatch:ListTagsForResource and cloudwatch:DeleteAlarms permissions to Database factory user.

