### PR TITLE
Adding option to select when to deploy R53 record for customer portal

### DIFF
--- a/terraform/aws/modules/customer-web-server/variables.tf
+++ b/terraform/aws/modules/customer-web-server/variables.tf
@@ -52,7 +52,6 @@ variable "cloud_vpn_cidr" {}
 
 variable "public_hosted_zoneid" {}
 
-
 variable "git_url" {}
 
 variable "git_path_cws" {}
@@ -72,3 +71,5 @@ variable "flux_git_url_cws" {}
 variable "cws_payment_url" {}
 
 variable "cws_payment_token" {}
+
+variable "enable_portal_r53_record" {}

--- a/terraform/aws/modules/customer-web-server/web-server.tf
+++ b/terraform/aws/modules/customer-web-server/web-server.tf
@@ -420,6 +420,8 @@ data "kubernetes_service" "nginx-public" {
 }
 
 resource "aws_route53_record" "customer_web_server" {
+  count = var.enable_portal_r53_record ? 1 : 0
+
   zone_id = var.public_hosted_zoneid
   name    = "portal"
   type    = "CNAME"


### PR DESCRIPTION
#### Summary
With this PR the option to select when a R53 record will be created for customer portal.
The reason for that is that we want this record to be created in Test environment but not in Prod because it is not managed in the account.