### PR TITLE
[MM 27333] Enable Teleport external storage in CnC and Gitlab clusters.

### DIFF
--- a/terraform/aws/modules/cluster/aws_auth_configmap.tf
+++ b/terraform/aws/modules/cluster/aws_auth_configmap.tf
@@ -1,9 +1,26 @@
-resource "kubernetes_config_map" "aws_auth_configmap" {
-  metadata {
-    name      = "aws-auth"
-    namespace = "kube-system"
-  }
-  data = {
+
+locals {
+  data = var.matterwick_cluster_access_enabled == true ? {
+    mapRoles = <<YAML
+  - rolearn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role"
+    username: system:node:{{EC2PrivateDNSName}}
+    groups:
+      - system:bootstrappers
+      - system:nodes
+  - rolearn: "${aws_iam_role.dev_access_role.arn}"
+    username: admin
+    groups:
+      - system:masters
+  - rolearn: "${data.aws_region.current.name == "us-east-1" ? aws_iam_role.lambda_role[0].arn : data.aws_iam_role.lambda_role[0].arn}"
+    username: admin
+    groups:
+      - system:masters
+  YAML
+    mapUsers = <<YAML
+  - userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.matterwick_iam_user}"
+    username: "${var.matterwick_username}"
+  YAML
+  } : {
     mapRoles = <<YAML
   - rolearn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role"
     username: system:node:{{EC2PrivateDNSName}}
@@ -20,6 +37,15 @@ resource "kubernetes_config_map" "aws_auth_configmap" {
       - system:masters
   YAML
   }
+}
+
+
+resource "kubernetes_config_map" "aws_auth_configmap" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+  data = local.data
   depends_on = [
     aws_eks_cluster.cluster,
     null_resource.cluster_services,

--- a/terraform/aws/modules/cluster/aws_auth_configmap.tf
+++ b/terraform/aws/modules/cluster/aws_auth_configmap.tf
@@ -20,7 +20,7 @@ locals {
   - userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.matterwick_iam_user}"
     username: "${var.matterwick_username}"
   YAML
-  } : {
+    } : {
     mapRoles = <<YAML
   - rolearn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role"
     username: system:node:{{EC2PrivateDNSName}}

--- a/terraform/aws/modules/cluster/variables.tf
+++ b/terraform/aws/modules/cluster/variables.tf
@@ -27,3 +27,5 @@ variable "eks_ami_id" {}
 variable "key_name" {}
 
 variable "teleport_cidr" {}
+
+variable "cluster_short_name" {}

--- a/terraform/aws/modules/cluster/variables.tf
+++ b/terraform/aws/modules/cluster/variables.tf
@@ -29,3 +29,9 @@ variable "key_name" {}
 variable "teleport_cidr" {}
 
 variable "cluster_short_name" {}
+
+variable "matterwick_cluster_access_enabled" {}
+
+variable "matterwick_iam_user" {}
+
+variable "matterwick_username" {}

--- a/terraform/aws/modules/cluster/worker_iam.tf
+++ b/terraform/aws/modules/cluster/worker_iam.tf
@@ -56,8 +56,7 @@ resource "aws_iam_policy" "teleport_policy" {
             "Effect": "Allow",
             "Action": "dynamodb:*",
             "Resource": [
-              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}",
-              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}/*"
+              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}*"
             ]
         }
     ]

--- a/terraform/aws/modules/cluster/worker_iam.tf
+++ b/terraform/aws/modules/cluster/worker_iam.tf
@@ -18,6 +18,58 @@ resource "aws_iam_role" "worker-role" {
 POLICY
 }
 
+resource "aws_iam_policy" "teleport_policy" {
+  name        = "cloud-${var.cluster_short_name}-teleport-policy"
+  path        = "/"
+  description = "Policy for Teleport required permissions."
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {   
+            "Sid": "AllS3Bucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:ListBucketVersions",
+                "s3:CreateBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-${var.environment}-${var.cluster_short_name}"
+            ]
+        },
+        {
+            "Sid": "AllS3Object",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:GetObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-${var.environment}-${var.cluster_short_name}/*"
+            ]
+        },
+        {
+            "Sid": "AllActionsOnTeleportDB",
+            "Effect": "Allow",
+            "Action": "dynamodb:*",
+            "Resource": [
+              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}",
+              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}/*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "worker_teleport_policy" {
+  policy_arn = aws_iam_policy.teleport_policy.arn
+  role       = aws_iam_role.worker-role.name
+}
+
 resource "aws_iam_role_policy_attachment" "worker-AmazonEKSWorkerNodePolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = aws_iam_role.worker-role.name

--- a/terraform/aws/modules/eks-cluster/variables.tf
+++ b/terraform/aws/modules/eks-cluster/variables.tf
@@ -31,3 +31,5 @@ variable "key_name" {}
 variable "teleport_cidr" {}
 
 variable "worker_private_subnet_ids" {}
+
+variable "cluster_short_name" {}

--- a/terraform/aws/modules/eks-cluster/worker_iam.tf
+++ b/terraform/aws/modules/eks-cluster/worker_iam.tf
@@ -56,8 +56,7 @@ resource "aws_iam_policy" "teleport_policy" {
             "Effect": "Allow",
             "Action": "dynamodb:*",
             "Resource": [
-              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}",
-              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}/*"
+              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}*"
             ]
         }
     ]

--- a/terraform/aws/modules/eks-cluster/worker_iam.tf
+++ b/terraform/aws/modules/eks-cluster/worker_iam.tf
@@ -18,6 +18,58 @@ resource "aws_iam_role" "worker-role" {
 POLICY
 }
 
+resource "aws_iam_policy" "teleport_policy" {
+  name        = "cloud-${var.cluster_short_name}-teleport-policy"
+  path        = "/"
+  description = "Policy for Teleport required permissions."
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {   
+            "Sid": "AllS3Bucket",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:ListBucketVersions",
+                "s3:CreateBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-${var.environment}-${var.cluster_short_name}"
+            ]
+        },
+        {
+            "Sid": "AllS3Object",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:GetObjectVersion"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-${var.environment}-${var.cluster_short_name}/*"
+            ]
+        },
+        {
+            "Sid": "AllActionsOnTeleportDB",
+            "Effect": "Allow",
+            "Action": "dynamodb:*",
+            "Resource": [
+              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}",
+              "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-${var.cluster_short_name}/*"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "worker_teleport_policy" {
+  policy_arn = aws_iam_policy.teleport_policy.arn
+  role       = aws_iam_role.worker-role.name
+}
+
 resource "aws_iam_role_policy_attachment" "worker-AmazonEKSWorkerNodePolicy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = aws_iam_role.worker-role.name

--- a/terraform/aws/modules/teleport/providers.tf
+++ b/terraform/aws/modules/teleport/providers.tf
@@ -32,3 +32,5 @@ provider "helm" {
     load_config_file       = false
   }
 }
+
+data "aws_region" "current" {}

--- a/terraform/aws/modules/teleport/teleport.tf
+++ b/terraform/aws/modules/teleport/teleport.tf
@@ -9,6 +9,22 @@ resource "helm_release" "teleport" {
     name  = "config.auth_service.cluster_name"
     value = "cloud-${var.environment}-${var.cluster_name}"
   }
+  set_string {
+    name  = "config.teleport.storage.region"
+    value = data.aws_region.current.name
+  }
+  set_string {
+    name  = "config.teleport.storage.table_name"
+    value = "cloud-${var.environment}-${var.cluster_name}"
+  }
+  set_string {
+    name  = "config.teleport.storage.audit_events_uri"
+    value = "dynamodb://cloud-${var.environment}-${var.cluster_name}-events"
+  }
+  set_string {
+    name  = "config.teleport.storage.audit_sessions_uri"
+    value = "s3://cloud-${var.environment}-${var.cluster_name}/records?region=${data.aws_region.current.name}"
+  }
   depends_on = [
     kubernetes_namespace.teleport,
   ]


### PR DESCRIPTION
#### Summary
With this PR:
- New cnc node policy is created for Teleport required permissions
- Teleport module is updated to include new set strings for external storage setup
- Local variables are created in auth configmap to support Mattewick access in Test environment

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27333

