### PR TITLE
[MM-27475] Adding DB subnet groups for PostgreSQL

### DIFF
--- a/terraform/aws/modules/subnet-and-networking-3az/provisioner_db_subnet_group.tf
+++ b/terraform/aws/modules/subnet-and-networking-3az/provisioner_db_subnet_group.tf
@@ -17,3 +17,26 @@ resource "aws_db_subnet_group" "provisioner_db_subnet_group" {
     var.tags
   )
 }
+
+resource "aws_db_subnet_group" "provisioner_db_subnet_group_postgresql" {
+
+  for_each = toset(var.vpc_cidrs)
+
+  name = "mattermost-provisioner-db-${data.aws_vpc.vpc_ids[each.value]["id"]}-postgresql"
+
+  subnet_ids = [
+    aws_subnet.private_1a[each.value]["id"],
+    aws_subnet.private_1b[each.value]["id"],
+    aws_subnet.private_1c[each.value]["id"],
+    aws_subnet.private_1d[each.value]["id"],
+    aws_subnet.private_1e[each.value]["id"],
+    aws_subnet.private_1f[each.value]["id"]
+  ]
+
+  tags = merge(
+    {
+      "MattermostCloudInstallationDatabase" = "PostgreSQL/Aurora"
+    },
+    var.tags
+  )
+}

--- a/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
+++ b/terraform/aws/modules/subnet-and-networking/provisioner_db_subnet_group.tf
@@ -20,3 +20,26 @@ resource "aws_db_subnet_group" "provisioner_db_subnet_group" {
     var.tags
   )
 }
+
+resource "aws_db_subnet_group" "provisioner_db_subnet_group_postgresql" {
+
+  for_each = toset(var.vpc_cidrs)
+
+  name = "mattermost-provisioner-db-${data.aws_vpc.vpc_ids[each.value]["id"]}-postgresql"
+
+  subnet_ids = [
+    aws_subnet.private_1a[each.value]["id"],
+    aws_subnet.private_1b[each.value]["id"],
+    aws_subnet.private_1c[each.value]["id"],
+    aws_subnet.private_1d[each.value]["id"],
+    aws_subnet.private_1e[each.value]["id"],
+    aws_subnet.private_1f[each.value]["id"]
+  ]
+
+  tags = merge(
+    {
+      "MattermostCloudInstallationDatabase" = "PostgreSQL/Aurora"
+    },
+    var.tags
+  )
+}


### PR DESCRIPTION
#### Summary
With this PR support for DB subnet groups deployment used by PostgreSQL DB clusters is added.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-27475

