### PR TITLE
add PutEncryptionConfiguration to provisioner be able to set Encryption in the s3 bucket

### DIFF
--- a/terraform/aws/modules/provisioner/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/provisioner/provisioner_user_permissions.tf
@@ -115,6 +115,7 @@ resource "aws_iam_policy" "s3" {
                 "s3:ListBucket",
                 "s3:GetBucketLocation",
                 "s3:CreateBucket",
+                "s3:PutEncryptionConfiguration",
                 "s3:PutBucketPublicAccessBlock",
                 "s3:GetBucketPublicAccessBlock",
                 "s3:PutObject",


### PR DESCRIPTION
#### Summary
add PutEncryptionConfiguration to provisioner be able to set Encryption in the s3 bucket

#### Ticket Link
Related to https://github.com/mattermost/mattermost-cloud/pull/293

Before merging the above PR we need to merge this pr and deploy this change in the environments

