### PR TITLE
[MM-28091] Moving provisioner permissions in a separate module to enable deployment of dev users in a single place

### DIFF
--- a/terraform/aws/modules/provisioner-users/locals.tf
+++ b/terraform/aws/modules/provisioner-users/locals.tf
@@ -1,0 +1,6 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  conditional_dash_region = data.aws_region.current.name == "us-east-1" ? "" : "-${data.aws_region.current.name}"
+}

--- a/terraform/aws/modules/provisioner-users/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/provisioner-users/provisioner_user_permissions.tf
@@ -115,6 +115,7 @@ resource "aws_iam_policy" "s3" {
                 "s3:ListBucket",
                 "s3:GetBucketLocation",
                 "s3:CreateBucket",
+                "s3:PutEncryptionConfiguration",
                 "s3:PutBucketPublicAccessBlock",
                 "s3:GetBucketPublicAccessBlock",
                 "s3:PutObject",

--- a/terraform/aws/modules/provisioner-users/provisioner_users.tf
+++ b/terraform/aws/modules/provisioner-users/provisioner_users.tf
@@ -1,0 +1,6 @@
+resource "aws_iam_user" "provisioner_users" {
+  for_each = toset(var.provisioner_users)
+  name     = each.value
+  path     = "/"
+  
+}

--- a/terraform/aws/modules/provisioner-users/provisioner_users.tf
+++ b/terraform/aws/modules/provisioner-users/provisioner_users.tf
@@ -2,5 +2,5 @@ resource "aws_iam_user" "provisioner_users" {
   for_each = toset(var.provisioner_users)
   name     = each.value
   path     = "/"
-  
+
 }

--- a/terraform/aws/modules/provisioner-users/variables.tf
+++ b/terraform/aws/modules/provisioner-users/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {}
+
+variable "provisioner_users" {}

--- a/terraform/aws/modules/provisioner/variables.tf
+++ b/terraform/aws/modules/provisioner/variables.tf
@@ -1,7 +1,5 @@
 variable "environment" {}
 
-variable "provisioner_users" {}
-
 variable "vpc_id" {}
 
 variable "region" {}


### PR DESCRIPTION
#### Summary
Moving provisioner permissions in a separate module to enable deployment of dev users in a single place

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-28091
