### PR TITLE
[MM-29019] Private DNS for mattermost-cloud is removed

### DIFF
--- a/terraform/aws/modules/provisioner/provisioner.tf
+++ b/terraform/aws/modules/provisioner/provisioner.tf
@@ -77,7 +77,7 @@ resource "kubernetes_deployment" "mattermost_cloud_main" {
         container {
           name  = "mattermost-cloud"
           image = var.mattermost_cloud_image
-          args  = ["server", "--debug", "--state-store", "mattermost-kops-state-${var.environment}", "--private-dns", "$(PRIVATE_DNS)", "--keep-filestore-data=$(KEEP_FILESTORE_DATA)", "--keep-database-data=$(KEEP_DATABASE_DATA)", "--database", "$(DATABASE)"]
+          args  = ["server", "--debug", "--state-store", "mattermost-kops-state-${var.environment}", "--keep-filestore-data=$(KEEP_FILESTORE_DATA)", "--keep-database-data=$(KEEP_DATABASE_DATA)", "--database", "$(DATABASE)"]
 
           port {
             name           = "api"
@@ -135,17 +135,6 @@ resource "kubernetes_deployment" "mattermost_cloud_main" {
               secret_key_ref {
                 name = "mattermost-cloud-secret"
                 key  = "DATABASE"
-              }
-            }
-          }
-
-          env {
-            name = "PRIVATE_DNS"
-
-            value_from {
-              secret_key_ref {
-                name = "mattermost-cloud-secret"
-                key  = "PRIVATE_DNS"
               }
             }
           }
@@ -285,7 +274,7 @@ resource "kubernetes_deployment" "mattermost_cloud_installations" {
         container {
           name  = "mattermost-cloud-installations"
           image = var.mattermost_cloud_image
-          args  = ["server", "--debug", "--cluster-supervisor=false", "--state-store", "mattermost-kops-state-${var.environment}", "--private-dns", "$(PRIVATE_DNS)", "--keep-filestore-data=$(KEEP_FILESTORE_DATA)", "--keep-database-data=$(KEEP_DATABASE_DATA)", "--database", "$(DATABASE)"]
+          args  = ["server", "--debug", "--cluster-supervisor=false", "--state-store", "mattermost-kops-state-${var.environment}", "--keep-filestore-data=$(KEEP_FILESTORE_DATA)", "--keep-database-data=$(KEEP_DATABASE_DATA)", "--database", "$(DATABASE)"]
 
           port {
             name           = "api"
@@ -343,17 +332,6 @@ resource "kubernetes_deployment" "mattermost_cloud_installations" {
               secret_key_ref {
                 name = "mattermost-cloud-secret"
                 key  = "DATABASE"
-              }
-            }
-          }
-
-          env {
-            name = "PRIVATE_DNS"
-
-            value_from {
-              secret_key_ref {
-                name = "mattermost-cloud-secret"
-                key  = "PRIVATE_DNS"
               }
             }
           }
@@ -471,7 +449,6 @@ resource "kubernetes_secret" "mattermost_cloud_secret" {
     AWS_SECRET_ACCESS_KEY = aws_iam_access_key.provisioner_user.secret
     AWS_REGION            = var.mattermost_cloud_secrets_aws_region
     DATABASE              = "postgres://${var.db_username}:${var.db_password}@${aws_db_instance.provisioner.endpoint}/${var.db_name}"
-    PRIVATE_DNS           = var.mattermost_cloud_secrets_private_dns
     KEEP_DATABASE_DATA    = var.mattermost_cloud_secrets_keep_database_data
     KEEP_FILESTORE_DATA   = var.mattermost_cloud_secrets_keep_filestore_data
   }

--- a/terraform/aws/modules/provisioner/variables.tf
+++ b/terraform/aws/modules/provisioner/variables.tf
@@ -38,8 +38,6 @@ variable "mattermost-cloud-namespace" {}
 
 variable "mattermost_cloud_secrets_aws_region" {}
 
-variable "mattermost_cloud_secrets_private_dns" {}
-
 variable "mattermost_cloud_secrets_keep_filestore_data" {}
 
 variable "mattermost_cloud_secrets_keep_database_data" {}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

You can see the log here:
The CLI [doesn't support the private-dns option](https://github.com/mattermost/mattermost-cloud/commit/485566eda810abdc5f2a3d6345e9d00c1cd95ffe#diff-bf5173f7bde99c71fd86043720c9c5d3bb52a48cca5c8d22da09e358b7d43c53) anymore so when deploy the cloud pods they're in the CrashLoopBackoff state until you remove this option.

```
$ k logs mattermost-cloud-installations-76c89d4854-m9g9t --previous
Usage:
  cloud server [flags]

Flags:
      --allow-list-cidr-range strings                The list of CIDRs to allow communication with the private ingress. (default [0.0.0.0/0])
      --cluster-installation-supervisor              Whether this server will run a cluster installation supervisor or not. (default true)
      --cluster-resource-threshold int               The percent threshold where new installations won't be scheduled on a multi-tenant cluster. (default 80)
      --cluster-resource-threshold-scale-value int   The number of worker nodes to scale up by when the threshold is passed. Set to 0 for no scaling. Scaling will never exceed the cluster max worker configuration value.
      --cluster-supervisor                           Whether this server will run a cluster supervisor or not. (default true)
      --database string                              The database backing the provisioning server. (default "sqlite://cloud.db")
      --debug                                        Whether to output debug logs.
      --dev                                          Set sane defaults for development
      --group-supervisor                             Whether this server will run an installation group supervisor or not.
  -h, --help                                         help for server
      --installation-supervisor                      Whether this server will run an installation supervisor or not. (default true)
      --keep-database-data                           Whether to preserve database data after installation deletion or not. (default true)
      --keep-filestore-data                          Whether to preserve filestore data after installation deletion or not. (default true)
      --listen string                                The interface and port on which to listen. (default ":8075")
      --machine-readable-logs                        Output the logs in machine readable format.
      --poll int                                     The interval in seconds to poll for background work. (default 30)
      --state-store string                           The S3 bucket used to store cluster state. (default "dev.cloud.mattermost.com")
      --use-existing-aws-resources                   Whether to use existing AWS resources (VPCs, subnets, etc.) or not. (default true)

time="2020-10-27T11:49:18Z" level=error msg="command failed" error="unknown flag: --private-dns"
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-29019