### PR TITLE
MM-25815 Migrate Helm2 releases to Helm3, module cleanup to follow Terraform 0.13 rules.

### DIFF
--- a/terraform/aws/modules/atlantis/atlantis.tf
+++ b/terraform/aws/modules/atlantis/atlantis.tf
@@ -10,7 +10,7 @@ resource "helm_release" "atlantis" {
   namespace = "atlantis"
   version   = var.atlantis_chart_version
   values = [
-    "${file(var.atlantis_chart_values_directory)}"
+    file(var.atlantis_chart_values_directory)
   ]
 
   set {

--- a/terraform/aws/modules/atlantis/nginx-internal.tf
+++ b/terraform/aws/modules/atlantis/nginx-internal.tf
@@ -15,7 +15,7 @@ resource "helm_release" "internal_nginx" {
   chart     = "stable/nginx-ingress"
   namespace = "nginx-internal"
   values = [
-    "${file(var.nginx_internal_chart_values_directory)}"
+    file(var.nginx_internal_chart_values_directory)
   ]
 
   set {

--- a/terraform/aws/modules/atlantis/providers.tf
+++ b/terraform/aws/modules/atlantis/providers.tf
@@ -1,6 +1,6 @@
 data "helm_repository" "stable" {
   name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
+  url  = "https://charts.helm.sh/stable"
 }
 
 

--- a/terraform/aws/modules/chartmuseum/chartmuseum.tf
+++ b/terraform/aws/modules/chartmuseum/chartmuseum.tf
@@ -9,7 +9,7 @@ resource "helm_release" "chartmuseum" {
   chart     = "stable/chartmuseum"
   namespace = "chartmuseum"
   values = [
-    "${file(var.chartmuseum_chart_values_directory)}"
+    file(var.chartmuseum_chart_values_directory)
   ]
 
   set {

--- a/terraform/aws/modules/chartmuseum/providers.tf
+++ b/terraform/aws/modules/chartmuseum/providers.tf
@@ -1,6 +1,6 @@
 data "helm_repository" "stable" {
   name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
+  url  = "https://charts.helm.sh/stable"
 }
 
 

--- a/terraform/aws/modules/cluster-post-installation/blackbox.tf
+++ b/terraform/aws/modules/cluster-post-installation/blackbox.tf
@@ -1,8 +1,8 @@
 resource "helm_release" "blackbox" {
   name       = "mattermost-cm-blackbox"
   namespace  = "monitoring"
-  repository = data.helm_repository.stable.metadata.0.name
-  chart      = "stable/prometheus-blackbox-exporter"
+  repository = "https://charts.helm.sh/stable"
+  chart      = "prometheus-blackbox-exporter"
   values = [
     file("../../../../chart-values/blackbox_values.yaml")
   ]

--- a/terraform/aws/modules/cluster-post-installation/es-curator.tf
+++ b/terraform/aws/modules/cluster-post-installation/es-curator.tf
@@ -1,8 +1,8 @@
 resource "helm_release" "es_curator" {
   name       = "mattermost-cm-es-curator"
   namespace  = "logging"
-  repository = data.helm_repository.stable.metadata.0.name
-  chart      = "stable/elasticsearch-curator"
+  repository = "https://charts.helm.sh/stable"
+  chart      = "elasticsearch-curator"
   values = [
     file("../../../../chart-values/elasticsearch-curator_values.yaml")
   ]

--- a/terraform/aws/modules/cluster-post-installation/fluent-bit.tf
+++ b/terraform/aws/modules/cluster-post-installation/fluent-bit.tf
@@ -1,8 +1,8 @@
 resource "helm_release" "fluent_bit" {
   name       = "mattermost-cm-fluent-bit"
   namespace  = "logging"
-  repository = data.helm_repository.stable.metadata.0.name
-  chart      = "stable/fluent-bit"
+  repository = "https://charts.helm.sh/stable"
+  chart      = "fluent-bit"
   values = [
     file("../../../../chart-values/fluent-bit_values.yaml")
   ]

--- a/terraform/aws/modules/cluster-post-installation/flux.tf
+++ b/terraform/aws/modules/cluster-post-installation/flux.tf
@@ -5,11 +5,12 @@ resource "null_resource" "flux_crd" {
 }
 
 resource "helm_release" "flux" {
-  name      = "mattermost-cm-flux"
-  chart     = "fluxcd/flux"
-  namespace = "flux"
+  name       = "mattermost-cm-flux"
+  chart      = "flux"
+  namespace  = "flux"
+  repository = "https://charts.fluxcd.io"
   values = [
-    "${file("../../../../chart-values/flux_values.yaml")}"
+    file("../../../../chart-values/flux_values.yaml")
   ]
 
   set {

--- a/terraform/aws/modules/cluster-post-installation/grafana.tf
+++ b/terraform/aws/modules/cluster-post-installation/grafana.tf
@@ -1,10 +1,11 @@
 resource "helm_release" "grafana" {
-  name      = "mattermost-cm-grafana"
-  namespace = "monitoring"
-  chart     = "grafana/grafana"
-  version   = var.grafana_chart_version
+  name       = "mattermost-cm-grafana"
+  namespace  = "monitoring"
+  chart      = "grafana"
+  repository = "https://grafana.github.io/helm-charts"
+  version    = var.grafana_chart_version
   values = [
-    "${file("../../../../chart-values/grafana_values.yaml")}"
+    file("../../../../chart-values/grafana_values.yaml")
   ]
   set_string {
     name  = "datasources.datasources\\.yaml.datasources[1].url"

--- a/terraform/aws/modules/cluster-post-installation/grafana_dashboard_configmaps.tf
+++ b/terraform/aws/modules/cluster-post-installation/grafana_dashboard_configmaps.tf
@@ -8,7 +8,7 @@ resource "kubernetes_config_map" "account_monitoring" {
   }
 
   data = {
-    "account_monitoring.json" = "${file("../../../../grafana-dashboards/account_monitoring.json")}"
+    "account_monitoring.json" = file("../../../../grafana-dashboards/account_monitoring.json")
   }
 }
 
@@ -22,7 +22,7 @@ resource "kubernetes_config_map" "account_view" {
   }
 
   data = {
-    "account_view.json" = "${file("../../../../grafana-dashboards/account_view.json")}"
+    "account_view.json" = file("../../../../grafana-dashboards/account_view.json")
   }
 }
 
@@ -36,7 +36,7 @@ resource "kubernetes_config_map" "alerting" {
   }
 
   data = {
-    "alerting.json" = "${file("../../../../grafana-dashboards/alerting.json")}"
+    "alerting.json" = file("../../../../grafana-dashboards/alerting.json")
   }
 }
 
@@ -50,7 +50,7 @@ resource "kubernetes_config_map" "aws_rds_overview" {
   }
 
   data = {
-    "aws_rds_overview.json" = "${file("../../../../grafana-dashboards/aws_rds_overview.json")}"
+    "aws_rds_overview.json" = file("../../../../grafana-dashboards/aws_rds_overview.json")
   }
 }
 
@@ -64,7 +64,7 @@ resource "kubernetes_config_map" "cluster_view" {
   }
 
   data = {
-    "cluster_view.json" = "${file("../../../../grafana-dashboards/cluster_view.json")}"
+    "cluster_view.json" = file("../../../../grafana-dashboards/cluster_view.json")
   }
 }
 
@@ -78,7 +78,7 @@ resource "kubernetes_config_map" "coredns" {
   }
 
   data = {
-    "coredns.json" = "${file("../../../../grafana-dashboards/coredns.json")}"
+    "coredns.json" = file("../../../../grafana-dashboards/coredns.json")
   }
 }
 
@@ -92,7 +92,7 @@ resource "kubernetes_config_map" "go_metrics_per_namespace_installation" {
   }
 
   data = {
-    "go_metrics_per_namespace_installation.json" = "${file("../../../../grafana-dashboards/go_metrics_per_namespace_installation.json")}"
+    "go_metrics_per_namespace_installation.json" = file("../../../../grafana-dashboards/go_metrics_per_namespace_installation.json")
   }
 }
 
@@ -106,7 +106,7 @@ resource "kubernetes_config_map" "installation_view" {
   }
 
   data = {
-    "installation_view.json" = "${file("../../../../grafana-dashboards/installation_view.json")}"
+    "installation_view.json" = file("../../../../grafana-dashboards/installation_view.json")
   }
 }
 
@@ -120,7 +120,7 @@ resource "kubernetes_config_map" "mattermost_performance_kpi_metrics_per_cluster
   }
 
   data = {
-    "mattermost_performance_kpi_metrics_per_cluster.json" = "${file("../../../../grafana-dashboards/mattermost_performance_kpi_metrics_per_cluster.json")}"
+    "mattermost_performance_kpi_metrics_per_cluster.json" = file("../../../../grafana-dashboards/mattermost_performance_kpi_metrics_per_cluster.json")
   }
 }
 
@@ -134,7 +134,7 @@ resource "kubernetes_config_map" "mattermost_performance_monitoring_per_cluster"
   }
 
   data = {
-    "mattermost_performance_monitoring_per_cluster.json" = "${file("../../../../grafana-dashboards/mattermost_performance_monitoring_per_cluster.json")}"
+    "mattermost_performance_monitoring_per_cluster.json" = file("../../../../grafana-dashboards/mattermost_performance_monitoring_per_cluster.json")
   }
 }
 
@@ -148,7 +148,7 @@ resource "kubernetes_config_map" "skydns" {
   }
 
   data = {
-    "skydns.json" = "${file("../../../../grafana-dashboards/skydns.json")}"
+    "skydns.json" = file("../../../../grafana-dashboards/skydns.json")
   }
 }
 
@@ -162,6 +162,6 @@ resource "kubernetes_config_map" "uptime_view" {
   }
 
   data = {
-    "uptime_view.json" = "${file("../../../../grafana-dashboards/uptime_view.json")}"
+    "uptime_view.json" = file("../../../../grafana-dashboards/uptime_view.json")
   }
 }

--- a/terraform/aws/modules/cluster-post-installation/prometheus_operator.tf
+++ b/terraform/aws/modules/cluster-post-installation/prometheus_operator.tf
@@ -1,11 +1,11 @@
 resource "helm_release" "prometheus_operator" {
   name       = "prometheus-operator"
   namespace  = "monitoring"
-  repository = data.helm_repository.prometheus_community.metadata.0.name
-  chart      = "prometheus-community/kube-prometheus-stack"
+  repository = "https://prometheus-community.github.io/helm-charts"
+  chart      = "kube-prometheus-stack"
   version    = var.prometheus_operator_chart_version
   values = [
-    "${file("../../../../chart-values/prometheus_operator_values.yaml")}"
+    file("../../../../chart-values/prometheus_operator_values.yaml")
   ]
   depends_on = [
     kubernetes_namespace.monitoring

--- a/terraform/aws/modules/cluster-post-installation/providers.tf
+++ b/terraform/aws/modules/cluster-post-installation/providers.tf
@@ -1,10 +1,8 @@
 data "aws_caller_identity" "current" {}
 
-# The data resources "helm_repository" are deprecated and should be removed after the migration
-# to the official helm charts, check: terraform/aws/modules/cluster-post-installation/grafana.tf#L4
 data "helm_repository" "stable" {
   name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
+  url  = "https://charts.helm.sh/stable"
 }
 
 data "helm_repository" "kiwigrid" {
@@ -28,26 +26,4 @@ data "aws_eks_cluster_auth" "cluster_auth" {
 
 data "aws_eks_cluster" "cluster" {
   name = var.deployment_name
-}
-
-provider "kubernetes" {
-  host                   = data.aws_eks_cluster.cluster.endpoint
-  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster_auth.token
-  load_config_file       = false
-  config_path            = "${var.kubeconfig_dir}/kubeconfig"
-}
-
-provider "helm" {
-  install_tiller  = true
-  service_account = "terraform-tiller"
-  namespace       = "kube-system"
-  tiller_image    = "gcr.io/kubernetes-helm/tiller:v${var.tiller_version}"
-  kubernetes {
-    config_path            = "${var.kubeconfig_dir}/kubeconfig"
-    host                   = data.aws_eks_cluster.cluster.endpoint
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-    token                  = data.aws_eks_cluster_auth.cluster_auth.token
-    load_config_file       = false
-  }
 }

--- a/terraform/aws/modules/cluster-post-installation/thanos.tf
+++ b/terraform/aws/modules/cluster-post-installation/thanos.tf
@@ -1,11 +1,11 @@
 resource "helm_release" "thanos" {
   name       = "thanos"
   namespace  = "monitoring"
-  repository = data.helm_repository.bitnami.metadata.0.name
-  chart      = "bitnami/thanos"
+  chart      = "thanos"
   version    = var.thanos_chart_version
+  repository = "https://charts.bitnami.com/bitnami/"
   values = [
-    "${file("../../../../chart-values/thanos.yaml")}"
+    file("../../../../chart-values/thanos.yaml")
   ]
   depends_on = [
     kubernetes_namespace.monitoring,
@@ -21,7 +21,7 @@ resource "kubernetes_config_map" "ruler_configmap" {
   }
 
   data = {
-    "ruler.yml" = "${file("../../../../thanos-rules/rules.yaml")}"
+    "ruler.yml" = file("../../../../thanos-rules/rules.yaml")
   }
 
   depends_on = [

--- a/terraform/aws/modules/customer-web-server/flux.tf
+++ b/terraform/aws/modules/customer-web-server/flux.tf
@@ -11,11 +11,12 @@ resource "kubernetes_namespace" "flux_cws" {
 }
 
 resource "helm_release" "flux" {
-  name      = "mattermost-cm-flux-cws"
-  chart     = "fluxcd/flux"
-  namespace = kubernetes_namespace.flux_cws.id
+  name       = "mattermost-cm-flux-cws"
+  chart      = "flux"
+  namespace  = kubernetes_namespace.flux_cws.id
+  repository = "https://charts.fluxcd.io"
   values = [
-    "${file("../../../../chart-values/flux_cws_values.yaml")}"
+    file("../../../../chart-values/flux_cws_values.yaml")
   ]
 
   set {

--- a/terraform/aws/modules/database-factory-scaling/cloud_db_factory_vertical_scaling.tf
+++ b/terraform/aws/modules/database-factory-scaling/cloud_db_factory_vertical_scaling.tf
@@ -75,7 +75,7 @@ data "aws_iam_policy_document" "sns_topic_policy" {
       variable = "AWS:SourceOwner"
 
       values = [
-        "${data.aws_caller_identity.current.account_id}",
+        data.aws_caller_identity.current.account_id,
       ]
     }
 

--- a/terraform/aws/modules/eks-cluster/kubeconfig.tf
+++ b/terraform/aws/modules/eks-cluster/kubeconfig.tf
@@ -1,5 +1,5 @@
 data "template_file" "kubeconfig" {
-  template = "${file("${path.module}/templates/kubeconfig.tpl")}"
+  template = file("${path.module}/templates/kubeconfig.tpl")
 
   vars = {
     cluster_name     = aws_eks_cluster.cluster.name

--- a/terraform/aws/modules/flux/flux.tf
+++ b/terraform/aws/modules/flux/flux.tf
@@ -16,7 +16,7 @@ resource "helm_release" "flux" {
   repository = data.helm_repository.fluxcd.metadata[0].name
   namespace  = var.flux_namespace
   values = [
-    "${file(format("../../../chart-values/%s", var.flux_chart_values_name))}"
+    file(format("../../../chart-values/%s", var.flux_chart_values_name))
   ]
 
   set {

--- a/terraform/aws/modules/gitlab/gitlab.tf
+++ b/terraform/aws/modules/gitlab/gitlab.tf
@@ -5,12 +5,13 @@ resource "null_resource" "gitlab_crd" {
 }
 
 resource "helm_release" "gitlab" {
-  name      = "gitlab"
-  chart     = "gitlab/gitlab"
-  namespace = "gitlab"
-  version   = var.gitlab_chart_version
+  name       = "gitlab"
+  chart      = "gitlab"
+  namespace  = "gitlab"
+  version    = var.gitlab_chart_version
+  repository = "https://charts.gitlab.io"
   values = [
-    "${file(var.gitlab_chart_values_directory)}"
+    file(var.gitlab_chart_values_directory)
   ]
 
   set {

--- a/terraform/aws/modules/gitlab/gitlab_cert.tf
+++ b/terraform/aws/modules/gitlab/gitlab_cert.tf
@@ -11,14 +11,22 @@ resource "aws_acm_certificate" "gitlab_cert" {
 
 resource "aws_acm_certificate_validation" "gitlab_cert_validation" {
   certificate_arn         = aws_acm_certificate.gitlab_cert.arn
-  validation_record_fqdns = [aws_route53_record.gitlab_validation.fqdn]
+  validation_record_fqdns = [for record in aws_route53_record.gitlab_validation : record.fqdn]
 }
 
 resource "aws_route53_record" "gitlab_validation" {
+  for_each = {
+    for dvo in aws_acm_certificate.gitlab_cert.domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  }
+
   zone_id = var.validation_hosted_zone_id
-  name    = aws_acm_certificate.gitlab_cert.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.gitlab_cert.domain_validation_options.0.resource_record_type
+  name    = each.value.name
+  type    = each.value.type
   ttl     = "300"
-  records = [aws_acm_certificate.gitlab_cert.domain_validation_options.0.resource_record_value]
+  records = [each.value.record]
 }
 

--- a/terraform/aws/modules/gitlab/providers.tf
+++ b/terraform/aws/modules/gitlab/providers.tf
@@ -20,7 +20,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
- 
+
   kubernetes {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)

--- a/terraform/aws/modules/gitlab/providers.tf
+++ b/terraform/aws/modules/gitlab/providers.tf
@@ -17,24 +17,16 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster_auth.token
   load_config_file       = false
-  config_path            = "${var.kubeconfig_dir}/kubeconfig"
-  version                = "1.10.0" #Locking version because newest breaks the provider
 }
 
 provider "helm" {
-  install_tiller  = true
-  service_account = "terraform-tiller"
-  namespace       = "kube-system"
-  tiller_image    = "gcr.io/kubernetes-helm/tiller:v${var.tiller_version}"
+ 
   kubernetes {
-    config_path            = "${var.kubeconfig_dir}/kubeconfig"
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster_auth.token
     load_config_file       = false
   }
-  version = "0.10.4"
-
 }
 
 

--- a/terraform/aws/modules/gitlab/s3.tf
+++ b/terraform/aws/modules/gitlab/s3.tf
@@ -1,41 +1,34 @@
 resource "aws_s3_bucket" "gitlab_registry" {
   bucket = var.gitlab_registry_bucket
-  region = "us-east-1"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "gitlab_lfs" {
   bucket = var.gitlab_lfs_bucket
-  region = "us-east-1"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "gitlab_artifacts" {
   bucket = var.gitlab_artifacts_bucket
-  region = "us-east-1"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "gitlab_uploads" {
   bucket = var.gitlab_uploads_bucket
-  region = "us-east-1"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "gitlab_packages" {
   bucket = var.gitlab_packages_bucket
-  region = "us-east-1"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "gitlab_backup" {
   bucket = var.gitlab_backup_bucket
-  region = "us-east-1"
   acl    = "private"
 }
 
 resource "aws_s3_bucket" "gitlab_backup_tmp" {
   bucket = var.gitlab_tmp_bucket
-  region = "us-east-1"
   acl    = "private"
 }

--- a/terraform/aws/modules/provisioner/locals.tf
+++ b/terraform/aws/modules/provisioner/locals.tf
@@ -13,7 +13,7 @@ data "terraform_remote_state" "cluster" {
 
 data "helm_repository" "stable" {
   name = "stable"
-  url  = "https://kubernetes-charts.storage.googleapis.com"
+  url  = "https://charts.helm.sh/stable"
 }
 
 locals {

--- a/terraform/aws/modules/public-ingress/nginx-public.tf
+++ b/terraform/aws/modules/public-ingress/nginx-public.tf
@@ -15,7 +15,7 @@ resource "helm_release" "public_nginx" {
   chart     = "stable/nginx-ingress"
   namespace = "nginx-public"
   values = [
-    "${file(var.nginx_chart_values_directory)}"
+    file(var.nginx_chart_values_directory)
   ]
 
   set {

--- a/terraform/aws/modules/teleport/providers.tf
+++ b/terraform/aws/modules/teleport/providers.tf
@@ -16,16 +16,10 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster_auth.token
   load_config_file       = false
-  config_path            = "${var.kubeconfig_dir}/kubeconfig"
 }
 
 provider "helm" {
-  install_tiller  = true
-  service_account = "terraform-tiller"
-  namespace       = "kube-system"
-  tiller_image    = "gcr.io/kubernetes-helm/tiller:v${var.tiller_version}"
   kubernetes {
-    config_path            = "${var.kubeconfig_dir}/kubeconfig"
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster_auth.token

--- a/terraform/aws/modules/teleport/teleport.tf
+++ b/terraform/aws/modules/teleport/teleport.tf
@@ -1,8 +1,8 @@
 resource "helm_release" "teleport" {
   name       = "teleport"
   namespace  = "teleport"
-  repository = data.helm_repository.chartmuseum.metadata.0.name
-  chart      = "chartmuseum/teleport"
+  repository = "https://chartmuseum.internal.core.cloud.mattermost.com/"
+  chart      = "teleport"
   version    = var.teleport_chart_version
 
   set_string {


### PR DESCRIPTION
#### Summary
- Migrate Helm2 releases to Helm3
- Module cleanup to follow Terraform 0.13 rules.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-25815