### PR TITLE
ES-curator doesn't exist on new helm artifactory

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/es-curator.tf
+++ b/terraform/aws/modules/cluster-post-installation/es-curator.tf
@@ -1,8 +1,8 @@
 resource "helm_release" "es_curator" {
   name       = "mattermost-cm-es-curator"
   namespace  = "logging"
-  repository = "https://charts.helm.sh/stable"
-  chart      = "elasticsearch-curator"
+  repository = data.helm_repository.stable.metadata.0.name
+  chart      = "stable/elasticsearch-curator"
   values = [
     file("../../../../chart-values/elasticsearch-curator_values.yaml")
   ]

--- a/terraform/aws/modules/cluster-post-installation/fluent-bit.tf
+++ b/terraform/aws/modules/cluster-post-installation/fluent-bit.tf
@@ -1,8 +1,8 @@
 resource "helm_release" "fluent_bit" {
   name       = "mattermost-cm-fluent-bit"
   namespace  = "logging"
-  repository = "https://charts.helm.sh/stable"
-  chart      = "fluent-bit"
+  repository = data.helm_repository.stable.metadata.0.name
+  chart      = "stable/fluent-bit"
   values = [
     file("../../../../chart-values/fluent-bit_values.yaml")
   ]


### PR DESCRIPTION
Fluent-bit changed a lot the templates. To avoid recreate templates for
now let's stick with the legacy "stable" chart

#### Summary
Fluent-bit changed a lot the templates. To avoid recreate templates for
now let's stick with the legacy "stable" chart

#### Ticket Link
`NONE`

