### PR TITLE
Fix deprecations

### DIFF
--- a/terraform/aws/modules/cluster-post-installation/flux.tf
+++ b/terraform/aws/modules/cluster-post-installation/flux.tf
@@ -33,9 +33,10 @@ resource "helm_release" "flux" {
     value = var.git_email
   }
 
-  set_string {
+  set {
     name  = "ssh.known_hosts"
     value = var.ssh_known_hosts
+    type  = "string"
   }
 
   set {

--- a/terraform/aws/modules/cluster-post-installation/grafana.tf
+++ b/terraform/aws/modules/cluster-post-installation/grafana.tf
@@ -7,9 +7,11 @@ resource "helm_release" "grafana" {
   values = [
     file("../../../../chart-values/grafana_values.yaml")
   ]
-  set_string {
+
+  set {
     name  = "datasources.datasources\\.yaml.datasources[1].url"
     value = var.aws_db_instance_provisioner_endpoint
+    type  = "string"
   }
   depends_on = [
     kubernetes_namespace.monitoring,

--- a/terraform/aws/modules/customer-web-server/flux.tf
+++ b/terraform/aws/modules/customer-web-server/flux.tf
@@ -39,9 +39,10 @@ resource "helm_release" "flux" {
     value = var.git_email
   }
 
-  set_string {
+  set {
     name  = "ssh.known_hosts"
     value = var.ssh_known_hosts
+    type  = "string"
   }
 
   set {

--- a/terraform/aws/modules/teleport/teleport.tf
+++ b/terraform/aws/modules/teleport/teleport.tf
@@ -5,25 +5,30 @@ resource "helm_release" "teleport" {
   chart      = "teleport"
   version    = var.teleport_chart_version
 
-  set_string {
+  set {
     name  = "config.auth_service.cluster_name"
     value = "cloud-${var.environment}-${var.cluster_name}"
+    type  = "string"
   }
-  set_string {
+  set {
     name  = "config.teleport.storage.region"
     value = data.aws_region.current.name
+    type  = "string"
   }
-  set_string {
+  set {
     name  = "config.teleport.storage.table_name"
     value = "cloud-${var.environment}-${var.cluster_name}"
+    type  = "string"
   }
-  set_string {
+  set {
     name  = "config.teleport.storage.audit_events_uri"
     value = "dynamodb://cloud-${var.environment}-${var.cluster_name}-events"
+    type  = "string"
   }
-  set_string {
+  set {
     name  = "config.teleport.storage.audit_sessions_uri"
     value = "s3://cloud-${var.environment}-${var.cluster_name}/records?region=${data.aws_region.current.name}"
+    type  = "string"
   }
   depends_on = [
     kubernetes_namespace.teleport,


### PR DESCRIPTION
 # Changes to be committed:

Substitute `set_string` with `set`. 

Ref.
```
set_string deprecation
set_string it's a very ad-hoc argument, implemented in a way that simply doesn't scale. set_sensitive was missing the functionality of string so following the pattern we should introduce set_sensitive_string what it's simply horrible.

Instead of doing this set_string has been deprecated in favor of set with the option type equal to string, behaves exactly as set_string. Additionally now set_sensitive also has the functionally as string.
```
#### Summary
Substitute `set_string` with `set`. 


#### Ticket Link
`NONE`

