### PR TITLE
MM-24482: Helm fixes

### DIFF
--- a/terraform/aws/modules/atlantis/atlantis.tf
+++ b/terraform/aws/modules/atlantis/atlantis.tf
@@ -5,10 +5,11 @@ resource "kubernetes_namespace" "atlantis" {
 }
 
 resource "helm_release" "atlantis" {
-  name      = "atlantis"
-  chart     = "runatlantis/atlantis"
-  namespace = "atlantis"
-  version   = var.atlantis_chart_version
+  name       = "atlantis"
+  chart      = "atlantis"
+  repository = "https://github.com/runatlantis/helm-charts"
+  namespace  = kubernetes_namespace.atlantis.metadata.name
+  version    = var.atlantis_chart_version
   values = [
     file(var.atlantis_chart_values_directory)
   ]

--- a/terraform/aws/modules/atlantis/providers.tf
+++ b/terraform/aws/modules/atlantis/providers.tf
@@ -3,7 +3,6 @@ data "helm_repository" "stable" {
   url  = "https://charts.helm.sh/stable"
 }
 
-
 data "aws_eks_cluster_auth" "cluster_auth" {
   name = var.deployment_name
 }
@@ -18,14 +17,4 @@ provider "kubernetes" {
   token                  = data.aws_eks_cluster_auth.cluster_auth.token
   load_config_file       = false
   config_path            = "${var.kubeconfig_dir}/kubeconfig"
-}
-
-provider "helm" {
-  kubernetes {
-    config_path            = "${var.kubeconfig_dir}/kubeconfig"
-    host                   = data.aws_eks_cluster.cluster.endpoint
-    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
-    token                  = data.aws_eks_cluster_auth.cluster_auth.token
-    load_config_file       = false
-  }
 }

--- a/terraform/aws/modules/atlantis/variables.tf
+++ b/terraform/aws/modules/atlantis/variables.tf
@@ -1,3 +1,5 @@
+variable "region" {}
+
 variable "deployment_name" {}
 
 variable "kubeconfig_dir" {}


### PR DESCRIPTION
Remove deprecated declarations

Try to fix:
```
in provider "helm":
  29:     load_config_file       = false

An argument named "load_config_file" is not expected here.
```
on terraform plan





