### PR TITLE
Update helm providers

### DIFF
--- a/terraform/aws/modules/atlantis/providers.tf
+++ b/terraform/aws/modules/atlantis/providers.tf
@@ -13,3 +13,12 @@ provider "kubernetes" {
   load_config_file       = false
   config_path            = "${var.kubeconfig_dir}/kubeconfig"
 }
+
+provider "helm" {
+  kubernetes {
+    config_path            = "${var.kubeconfig_dir}/kubeconfig"
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster_auth.token
+  }
+}

--- a/terraform/aws/modules/chartmuseum/providers.tf
+++ b/terraform/aws/modules/chartmuseum/providers.tf
@@ -26,6 +26,5 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster_auth.token
-    load_config_file       = false
   }
 }

--- a/terraform/aws/modules/flux/providers.tf
+++ b/terraform/aws/modules/flux/providers.tf
@@ -27,6 +27,5 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster_auth.token
-    load_config_file       = false
   }
 }

--- a/terraform/aws/modules/gitlab/providers.tf
+++ b/terraform/aws/modules/gitlab/providers.tf
@@ -25,7 +25,6 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster_auth.token
-    load_config_file       = false
   }
 }
 

--- a/terraform/aws/modules/public-ingress/providers.tf
+++ b/terraform/aws/modules/public-ingress/providers.tf
@@ -26,6 +26,5 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster_auth.token
-    load_config_file       = false
   }
 }

--- a/terraform/aws/modules/teleport/providers.tf
+++ b/terraform/aws/modules/teleport/providers.tf
@@ -23,7 +23,6 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     token                  = data.aws_eks_cluster_auth.cluster_auth.token
-    load_config_file       = false
   }
 }
 


### PR DESCRIPTION
Following cluster_post_installation setup.
Remove failing load_config_value parameter.
Add back helm provider to atlantis

