### PR TITLE
Reserving Resources For The System and Kubelet

### DIFF
--- a/terraform/aws/modules/cluster/worker_asg.tf
+++ b/terraform/aws/modules/cluster/worker_asg.tf
@@ -3,7 +3,7 @@ locals {
   worker-userdata = <<USERDATA
 #!/bin/bash
 set -o xtrace
-/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.cluster.endpoint}' --b64-cluster-ca '${aws_eks_cluster.cluster.certificate_authority.0.data}' '${var.deployment_name}'
+/etc/eks/bootstrap.sh --apiserver-endpoint '${aws_eks_cluster.cluster.endpoint}' --b64-cluster-ca '${aws_eks_cluster.cluster.certificate_authority.0.data}' '${var.deployment_name}' --kubelet-extra-args "--kube-reserved cpu=250m,memory=1Gi,ephemeral-storage=1Gi --system-reserved cpu=250m,memory=0.2Gi,ephemeral-storage=1Gi --eviction-hard memory.available<0.2Gi,nodefs.available<10%"
 USERDATA
 }
 


### PR DESCRIPTION
Noticed some OOM on kubelet operations and Nodes become not ready on
test environment.

The idea for these flags come from a useful resource regarding running
EKS on production. ref. https://kubedex.com/90-days-of-aws-eks-in-production/

#### Summary
Reserving Resources For The System and Kubelet

#### Ticket Link
`NONE`

