### PR TITLE
Bug-fix: Cannot use key AWS_REGION in ENV_VARIABLE

### DIFF
--- a/lambda-functions/deckhand/main.go
+++ b/lambda-functions/deckhand/main.go
@@ -23,7 +23,7 @@ func main() {
 
 func handler() {
 	sess, err := session.NewSession(&aws.Config{
-		Region: aws.String(os.Getenv("AWS_REGION"))},
+		Region: aws.String(os.Getenv("REGION"))},
 	)
 	if err != nil {
 		log.WithError(err).Error("AWS Session failed.")

--- a/terraform/aws/modules/cleanup-unused-images/lambdas.tf
+++ b/terraform/aws/modules/cleanup-unused-images/lambdas.tf
@@ -16,8 +16,8 @@ resource "aws_lambda_function" "deckhand" {
 
   environment {
     variables = {
-      "AWS_REGION" = var.region
-      "OWNER_ID"   = var.account_id
+      "REGION"   = var.region
+      "OWNER_ID" = var.account_id
     }
   }
 


### PR DESCRIPTION

#### Summary
```
Lambda was unable to configure your environment variables because the environment variables you have provided contains reserved keys that are currently not supported for modification. Reserved keys used in this request: AWS_REGION
```
Renaming to REGION.




