### PR TITLE
Add event target needed for lambda to be cron

### DIFF
--- a/terraform/aws/modules/cleanup-unused-images/cloudwatch.tf
+++ b/terraform/aws/modules/cleanup-unused-images/cloudwatch.tf
@@ -7,6 +7,12 @@ resource "aws_cloudwatch_event_rule" "deckhandcron" {
   schedule_expression = "cron(0 10 ? * MON *)" #runs every monday at 10am UTC
 }
 
+resource "aws_cloudwatch_event_target" "deckhand-lambda-target" {
+  target_id = "deckhand-lambda-target"
+  rule      = aws_cloudwatch_event_rule.deckhandcron.name
+  arn       = aws_lambda_function.deckhand.arn
+}
+
 resource "aws_cloudwatch_metric_alarm" "lambda_deckhand_errors" {
   alarm_name          = "Lambda deckhand - Errors"
   alarm_description   = "This lambda cleans up unused images 30days old or more and their snapshots. This alarm indicates the lambda had Errors when it was executed."

--- a/terraform/aws/modules/cleanup-unused-images/iam.tf
+++ b/terraform/aws/modules/cleanup-unused-images/iam.tf
@@ -46,7 +46,10 @@ resource "aws_iam_role_policy" "cleanup_old_images_lambda_policy" {
             "ec2:DeregisterImage",
             "ec2:DescribeInstances",
             "ec2:DescribeSnapshots",
-            "ec2:DeleteSnapshot"
+            "ec2:DeleteSnapshot",
+            "ec2:CreateNetworkInterface",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DeleteNetworkInterface"
         ],
         "Resource": [
             "*"


### PR DESCRIPTION
Add back required permissions for lambda creation

#### Summary
Add event target needed for lambda to be cron.
Add back required permissions for lambda creation.


