### PR TITLE
[MM-29654] Split internal ingress for CWS

### DIFF
--- a/terraform/aws/modules/customer-web-server/variables.tf
+++ b/terraform/aws/modules/customer-web-server/variables.tf
@@ -44,6 +44,8 @@ variable "cws_ingress" {}
 
 variable "cws_ingress_internal" {}
 
+variable "cws_ingress_api_internal" {}
+
 variable "cws_image_version" {}
 
 variable "cws_smtp_username" {}

--- a/terraform/aws/modules/provisioner/route53.tf
+++ b/terraform/aws/modules/provisioner/route53.tf
@@ -1,7 +1,7 @@
 data "kubernetes_service" "nginx-internal" {
   metadata {
-    name      = "nginx-ingress-nginx-controller-internal"
-    namespace = "nginx"
+    name      = "nginx-internal-ingress-nginx-controller"
+    namespace = "nginx-internal"
   }
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

In order to make it possible to CIDR filtering for CWS, we need to expose the public API through the internal endpoint so we can filter based on our internal cluster API.

The current internal endpoint/ingress is renamed as api.internal and that would lead to the CWS internal API

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

https://mattermost.atlassian.net/browse/MM-29654
