### PR TITLE
Fix permissions of database factory user to be able to modify the cluster

### DIFF
--- a/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
+++ b/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
@@ -13,6 +13,7 @@ resource "aws_iam_policy" "rds_db_factory" {
             "Action": [
                 "rds:CreateDBCluster",
                 "rds:DeleteDBCluster",
+                "rds:ModifyDBCluster",
                 "rds:CreateDBClusterParameterGroup",
                 "rds:ModifyDBClusterParameterGroup",
                 "rds:DescribeDBClusterParameterGroups",


### PR DESCRIPTION
#### Summary
Database factory was failing in test as we were lacking the permission
for modifying the DB cluster.

#### Ticket Link
 https://mattermost.atlassian.net/browse/MM-34230

