### PR TITLE
Add new pipeline to support multiregion lambda deployments.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,16 @@ workflows:
     jobs:
       - push-lambda:
           file_dir: $(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/
+          bucket_name: releases-us-east-2.mattermost.com
+          lambda_function: deckhand
+          zip_file_name: main.zip
+          context: releases-us-east-2.mattermost.com
+          filters:
+            branches:
+              only:
+                - master
+      - push-lambda:
+          file_dir: $(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/
           bucket_name: releases.mattermost.com
           lambda_function: deckhand
           zip_file_name: main.zip

--- a/terraform/aws/modules/cleanup-unused-images/lambdas.tf
+++ b/terraform/aws/modules/cleanup-unused-images/lambdas.tf
@@ -1,6 +1,6 @@
 # Lambda function for clenaing up old and unused images.
 resource "aws_lambda_function" "deckhand" {
-  s3_bucket     = "releases.mattermost.com"
+  s3_bucket     = var.bucket
   s3_key        = "mattermost-cloud/deckhand/master/main.zip"
   function_name = "deckhand"
   description   = "Lambda"

--- a/terraform/aws/modules/cleanup-unused-images/variables.tf
+++ b/terraform/aws/modules/cleanup-unused-images/variables.tf
@@ -7,3 +7,6 @@ variable "deployment_name" {}
 variable "region" {}
 
 variable "account_id" {}
+
+variable "bucket" {}
+


### PR DESCRIPTION
Make s3 bucket variable for deckhand lambda as we need to deploy it in multiple buckets.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add new pipeline to support multiregion lambda deployments.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34662

