### PR TITLE
Fix read replica remove the subnet group

### DIFF
--- a/terraform/aws/modules/customer-web-server/variables.tf
+++ b/terraform/aws/modules/customer-web-server/variables.tf
@@ -26,6 +26,10 @@ variable "cws_db_engine_version" {}
 
 variable "cws_db_instance_class" {}
 
+variable "cws_db_master_az" {}
+
+variable "cws_db_read_replica_az" {}
+
 variable "cws_db_name" {}
 
 variable "cws_db_username" {}

--- a/terraform/aws/modules/customer-web-server/web-server.tf
+++ b/terraform/aws/modules/customer-web-server/web-server.tf
@@ -81,6 +81,7 @@ resource "aws_db_instance" "cws_postgres" {
   skip_final_snapshot         = false
   maintenance_window          = var.cws_db_maintenance_window
   publicly_accessible         = false
+  availability_zone           = var.cws_db_master_az
   # snapshot_identifier         = var.cws_snapshot_identifier
   storage_encrypted = var.cws_storage_encrypted
 
@@ -102,16 +103,12 @@ resource "aws_db_instance" "cws_postgres_read_replica" {
   deletion_protection         = true
 
   # networking
-  db_subnet_group_name   = aws_db_subnet_group.cws_subnets_db.name
   vpc_security_group_ids = [aws_security_group.cws_postgres_sg.id]
   publicly_accessible    = false
+  availability_zone      = var.cws_db_read_replica_az
 
   # backup & maintenance
-  backup_retention_period   = var.cws_db_backup_retention_period
-  backup_window             = var.cws_db_backup_window
-  maintenance_window        = var.cws_db_maintenance_window
-  final_snapshot_identifier = "customer-web-server-final-${local.db_name_read_replica}-${local.timestamp_now}"
-  skip_final_snapshot       = false
+  maintenance_window = var.cws_db_maintenance_window
 
   # replication read replica
   replicate_source_db = aws_db_instance.cws_postgres.identifier

--- a/terraform/aws/modules/provisioner/provisioner-db.tf
+++ b/terraform/aws/modules/provisioner/provisioner-db.tf
@@ -72,6 +72,7 @@ resource "aws_db_instance" "provisioner" {
   publicly_accessible         = false
   snapshot_identifier         = var.snapshot_identifier
   storage_encrypted           = var.storage_encrypted
+  availability_zone           = var.db_master_az
 
   tags = {
     Name        = "Provisioner"
@@ -97,17 +98,12 @@ resource "aws_db_instance" "provisioner_read_replica" {
   deletion_protection         = var.db_deletion_protection
 
   # networking
-  db_subnet_group_name   = aws_db_subnet_group.subnets_db.name
   vpc_security_group_ids = [aws_security_group.cec_to_postgress.id]
   publicly_accessible    = false
+  availability_zone      = var.db_read_replica_az
 
   # backup & maintenance
-  backup_retention_period   = var.db_backup_retention_period
-  backup_window             = var.db_backup_window
-  maintenance_window        = var.db_maintenance_window
-  final_snapshot_identifier = "provisioner-final-${local.db_name_read_replica}-${local.timestamp_now}"
-  snapshot_identifier       = var.snapshot_identifier
-  skip_final_snapshot       = false
+  maintenance_window = var.db_maintenance_window
 
   # replication read replica
   replicate_source_db = aws_db_instance.provisioner.identifier

--- a/terraform/aws/modules/provisioner/variables.tf
+++ b/terraform/aws/modules/provisioner/variables.tf
@@ -14,6 +14,10 @@ variable "db_engine_version" {}
 
 variable "db_instance_class" {}
 
+variable "db_master_az" {}
+
+variable "db_read_replica_az" {}
+
 variable "db_name" {}
 
 variable "db_username" {}


### PR DESCRIPTION
#### Summary
Read replica doesn't need subnet group when it is in the same
region and there is no need for backups for replicas. Set
availability zone to be assigned and not use the same as master

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34759


