### PR TITLE
Add permission needed by k8s-spot-termination-handler

### DIFF
--- a/terraform/aws/modules/vpc-setup/cluster_nodes_iam.tf
+++ b/terraform/aws/modules/vpc-setup/cluster_nodes_iam.tf
@@ -51,6 +51,15 @@ resource "aws_iam_policy" "node_policy" {
             "Effect": "Allow",
             "Action": "dynamodb:*",
             "Resource": "arn:aws:dynamodb:*:${data.aws_caller_identity.current.account_id}:table/cloud-${var.environment}-*"
+        },
+        {
+            "Action": [
+                "autoscaling:DescribeAutoScalingInstances"
+            ],
+            "Effect": "Allow",
+            "Resource": [
+                "*"
+            ]
         }
     ]
 }


### PR DESCRIPTION
#### Summary
Add permission needed by k8s-spot-termination-handler. 
k8s-spot-termination-handler pods need to be able to describe ASG instances. 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34603

