### PR TITLE
Add cloudwatch alarms for elasticsearch

### DIFF
--- a/terraform/aws/modules/elasticsearch/locals.tf
+++ b/terraform/aws/modules/elasticsearch/locals.tf
@@ -1,0 +1,11 @@
+locals {
+  thresholds = {
+    FreeStorageSpaceThreshold        = max(var.free_storage_space_threshold, 0)
+    MinimumAvailableNodes            = max(var.min_available_nodes, 0)
+    CPUUtilizationThreshold          = min(max(var.cpu_utilization_threshold, 0), 100)
+    JVMMemoryPressureThreshold       = min(max(var.jvm_memory_pressure_threshold, 0), 100)
+    MasterCPUUtilizationThreshold    = min(max(coalesce(var.master_cpu_utilization_threshold, var.cpu_utilization_threshold), 0), 100)
+    MasterJVMMemoryPressureThreshold = min(max(coalesce(var.master_jvm_memory_pressure_threshold, var.jvm_memory_pressure_threshold), 0), 100)
+  }
+  aws_sns_topic_arn = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
+}

--- a/terraform/aws/modules/elasticsearch/locals.tf
+++ b/terraform/aws/modules/elasticsearch/locals.tf
@@ -7,5 +7,5 @@ locals {
     MasterCPUUtilizationThreshold    = min(max(coalesce(var.master_cpu_utilization_threshold, var.cpu_utilization_threshold), 0), 100)
     MasterJVMMemoryPressureThreshold = min(max(coalesce(var.master_jvm_memory_pressure_threshold, var.jvm_memory_pressure_threshold), 0), 100)
   }
-  aws_sns_topic_arn = ["arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"]
+  aws_sns_topic_arn = "arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"
 }

--- a/terraform/aws/modules/elasticsearch/monitoring.tf
+++ b/terraform/aws/modules/elasticsearch/monitoring.tf
@@ -1,0 +1,182 @@
+
+resource "aws_cloudwatch_metric_alarm" "cluster_status_is_red" {
+  count               = var.monitor_cluster_status_is_red ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterStatusIsRed${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ClusterStatus.red"
+  namespace           = "AWS/ES"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "Average elasticsearch cluster status is in red over last 1 minutes"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+
+  dimensions = {
+    DomainName = var.domain_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "cluster_status_is_yellow" {
+  count               = var.monitor_cluster_status_is_yellow ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterStatusIsYellow${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ClusterStatus.yellow"
+  namespace           = "AWS/ES"
+  period              = "60"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "Average elasticsearch cluster status is in yellow over last 1 minutes"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+
+  dimensions = {
+    DomainName = var.domain_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "free_storage_space_too_low" {
+  count               = var.monitor_free_storage_space_too_low ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-FreeStorageSpaceTooLow${var.alarm_name_postfix}"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "FreeStorageSpace"
+  namespace           = "AWS/ES"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = local.thresholds["FreeStorageSpaceThreshold"]
+  alarm_description   = "Average elasticsearch free storage space over last 1 minutes is too low"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+
+  dimensions = {
+    DomainName = var.domain_name
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "cluster_index_writes_blocked" {
+  count               = var.monitor_cluster_index_writes_blocked ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterIndexWritesBlocked${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "ClusterIndexWritesBlocked"
+  namespace           = "AWS/ES"
+  period              = "300"
+  statistic           = "Maximum"
+  threshold           = "1"
+  alarm_description   = "Elasticsearch index writes being blocker over last 5 minutes"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.current.account_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "insufficient_available_nodes" {
+  count               = var.monitor_insufficient_available_nodes ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-InsufficientAvailableNodes${var.alarm_name_postfix}"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "Nodes"
+  namespace           = "AWS/ES"
+  period              = "86400"
+  statistic           = "Minimum"
+  threshold           = local.thresholds["MinimumAvailableNodes"]
+  alarm_description   = "Elasticsearch nodes minimum < ${local.thresholds["MinimumAvailableNodes"]} for 1 day"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.current.account_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_utilization_too_high" {
+  count               = var.monitor_cpu_utilization_too_high ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-CPUUtilizationTooHigh${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/ES"
+  period              = "900"
+  statistic           = "Average"
+  threshold           = local.thresholds["CPUUtilizationThreshold"]
+  alarm_description   = "Average elasticsearch cluster CPU utilization over last 45 minutes too high"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.current.account_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "jvm_memory_pressure_too_high" {
+  count               = var.monitor_jvm_memory_pressure_too_high ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-JVMMemoryPressure${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "JVMMemoryPressure"
+  namespace           = "AWS/ES"
+  period              = "900"
+  statistic           = "Maximum"
+  threshold           = local.thresholds["JVMMemoryPressureThreshold"]
+  alarm_description   = "Elasticsearch JVM memory pressure is too high over last 15 minutes"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.current.account_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "master_cpu_utilization_too_high" {
+  count               = var.monitor_master_cpu_utilization_too_high ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-MasterCPUUtilizationTooHigh${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "MasterCPUUtilization"
+  namespace           = "AWS/ES"
+  period              = "900"
+  statistic           = "Average"
+  threshold           = local.thresholds["MasterCPUUtilizationThreshold"]
+  alarm_description   = "Average elasticsearch cluster CPU utilization over last 45 minutes too high"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.current.account_id
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "master_jvm_memory_pressure_too_high" {
+  count               = var.monitor_master_jvm_memory_pressure_too_high ? 1 : 0
+  alarm_name          = "${var.alarm_name_prefix}ElasticSearch-MasterJVMMemoryPressure${var.alarm_name_postfix}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "MasterJVMMemoryPressure"
+  namespace           = "AWS/ES"
+  period              = "900"
+  statistic           = "Maximum"
+  threshold           = local.thresholds["MasterJVMMemoryPressureThreshold"]
+  alarm_description   = "Elasticsearch JVM memory pressure is too high over last 15 minutes"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+
+  dimensions = {
+    DomainName = var.domain_name
+    ClientId   = data.aws_caller_identity.current.account_id
+  }
+}

--- a/terraform/aws/modules/elasticsearch/variables.tf
+++ b/terraform/aws/modules/elasticsearch/variables.tf
@@ -34,3 +34,105 @@ variable "cw_retention_in_days" {
   type    = string
   default = "90"
 }
+
+variable "alarm_name_prefix" {
+  description = "Alarm name prefix"
+  type        = string
+  default     = ""
+}
+
+variable "alarm_name_postfix" {
+  description = "Alarm name postfix"
+  type        = string
+  default     = ""
+}
+
+variable "monitor_cluster_status_is_red" {
+  description = "Enable monitoring of cluster status is in red"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_cluster_status_is_yellow" {
+  description = "Enable monitoring of cluster status is in yellow"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_free_storage_space_too_low" {
+  description = "Enable monitoring of cluster average free storage is to low"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_cluster_index_writes_blocked" {
+  description = "Enable monitoring of cluster index writes being blocked"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_insufficient_available_nodes" {
+  description = "Enable monitoring insufficient available nodes"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_cpu_utilization_too_high" {
+  description = "Enable monitoring of CPU utilization is too high"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_jvm_memory_pressure_too_high" {
+  description = "Enable monitoring of JVM memory pressure is too high"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_master_cpu_utilization_too_high" {
+  description = "Enable monitoring of CPU utilization of master nodes are too high. Only enable this when dedicated master is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "monitor_master_jvm_memory_pressure_too_high" {
+  description = "Enable monitoring of JVM memory pressure of master nodes are too high. Only enable this wwhen dedicated master is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "free_storage_space_threshold" {
+  description = "The minimum amount of available storage space in MegaByte."
+  type        = number
+  default     = 11000 //MB 10%
+}
+
+variable "min_available_nodes" {
+  description = "The minimum available (reachable) nodes to have"
+  type        = number
+  default     = 1
+}
+
+variable "cpu_utilization_threshold" {
+  description = "The maximum percentage of CPU utilization"
+  type        = number
+  default     = 80
+}
+
+variable "jvm_memory_pressure_threshold" {
+  description = "The maximum percentage of the Java heap used for all data nodes in the cluster"
+  type        = number
+  default     = 80
+}
+
+variable "master_cpu_utilization_threshold" {
+  description = "The maximum percentage of CPU utilization of master nodes"
+  type        = number
+  default     = 80
+}
+
+variable "master_jvm_memory_pressure_threshold" {
+  description = "The maximum percentage of the Java heap used for master nodes in the cluster"
+  type        = number
+  default     = 80
+}


### PR DESCRIPTION
#### Summary
Alarms for:
- FreeStorageSpace
- ClusterIndexWritesBlocked
- ClusterStatus.yellow/red
- Min Nodes
- CPUUtilization
- JVMMemoryPressure
- MasterCPUUtilization
- MasterJVMMemoryPressure

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-34089

