### PR TITLE
Change fluentbit helm to the official chart

### DIFF
--- a/terraform/aws/modules/cluster-logging/fluent-bit.tf
+++ b/terraform/aws/modules/cluster-logging/fluent-bit.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "fluent_bit" {
   name       = "mattermost-cm-fluent-bit"
   namespace  = "logging"
-  repository = "https://charts.helm.sh/stable"
+  repository = "https://fluent.github.io/helm-charts"
   chart      = "fluent-bit"
   version    = var.fluent_bit_chart_version
   values = [

--- a/terraform/aws/modules/cluster-post-installation/fluent-bit.tf
+++ b/terraform/aws/modules/cluster-post-installation/fluent-bit.tf
@@ -1,7 +1,7 @@
 resource "helm_release" "fluent_bit" {
   name       = "mattermost-cm-fluent-bit"
   namespace  = "logging"
-  repository = "https://charts.helm.sh/stable"
+  repository = "https://fluent.github.io/helm-charts"
   chart      = "fluent-bit"
   version    = var.fluent_bit_chart_version
   values = [


### PR DESCRIPTION
#### Summary
We are bumping the version of fluent-bit and we need to source the new
official helm chart.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM=35208

