### PR TITLE
Fix service account of atlantis to have the right permissions

### DIFF
--- a/terraform/aws/modules/atlantis/rbac.tf
+++ b/terraform/aws/modules/atlantis/rbac.tf
@@ -1,0 +1,53 @@
+resource "kubernetes_cluster_role" "atlantis" {
+  metadata {
+    name = "atlantis"
+    labels = {
+      app = "atlantis"
+    }
+  }
+
+
+  rule {
+    api_groups = [""]
+    resources = [
+      "secrets",
+      "configmaps",
+      "namespaces",
+      "serviceaccounts",
+    ]
+    verbs = ["watch", "list", "get"]
+  }
+
+  rule {
+    api_groups = ["rbac.authorization.k8s.io"]
+    resources = [
+      "roles",
+      "clusterroles",
+      "clusterrolebindings",
+      "rolebindings",
+    ]
+    verbs = ["watch", "list", "get"]
+  }
+}
+
+resource "kubernetes_cluster_role_binding" "atlantis" {
+  metadata {
+    name = "atlantis"
+    labels = {
+      app = "atlantis"
+    }
+  }
+  role_ref {
+    api_group = "rbac.authorization.k8s.io"
+    kind      = "ClusterRole"
+    name      = "atlantis"
+  }
+  subject {
+    kind      = "ServiceAccount"
+    name      = "atlantis"
+    namespace = "atlantis"
+  }
+  depends_on = [
+    kubernetes_cluster_role.atlantis,
+  ]
+}


### PR DESCRIPTION
#### Summary
We need to give access to watch and list other k8s resources which are needed so
we can runn terraform operations with atlantis. The current issue is that it's missing
permissions to describe specific resources so the terraform operations fail.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35192

