### PR TITLE
Fix: Get eks token with exec

### DIFF
--- a/terraform/aws/modules/cluster/providers.tf
+++ b/terraform/aws/modules/cluster/providers.tf
@@ -1,15 +1,9 @@
-data "aws_eks_cluster_auth" "cluster_auth" {
-  name = var.deployment_name
-  depends_on = [
-    aws_eks_cluster.cluster,
-    aws_autoscaling_group.worker-asg,
-    aws_iam_role.lambda_role
-  ]
-}
-
 provider "kubernetes" {
   host                   = aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)
-  token                  = data.aws_eks_cluster_auth.cluster_auth.token
-  load_config_file       = false
+  exec {
+    api_version = "client.authentication.k8s.io/v1alpha1"
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.cluster.name]
+    command     = "aws"
+  }
 }


### PR DESCRIPTION
#### Summary

**Reasoning:**
Some cloud providers have short-lived authentication tokens that can expire relatively quickly. To ensure the Kubernetes provider is receiving valid credentials, an exec-based plugin can be used to fetch a new token before initializing the provider. For example, on EKS.

**Reference:**
https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35549

