### PR TITLE
Pass AWS_PROFILE as param

### DIFF
--- a/terraform/aws/modules/cluster/providers.tf
+++ b/terraform/aws/modules/cluster/providers.tf
@@ -3,7 +3,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)
   exec {
     api_version = "client.authentication.k8s.io/v1alpha1"
-    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.cluster.name]
+    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.cluster.name, "--profile", var.aws_profile]
     command     = "aws"
   }
 }

--- a/terraform/aws/modules/cluster/variables.tf
+++ b/terraform/aws/modules/cluster/variables.tf
@@ -46,3 +46,5 @@ variable "provider_role_arn" {
 variable "cnc_user" {}
 
 variable "log_types" {}
+
+variable "aws_profile" {}


### PR DESCRIPTION
If this commit applied aws profile could pass as param on cluster module when it get's token. This way can be ensured that it will use the profile which had the proper permissions and not one inherited from EC2 instance role.
Issue: MM-35549

#### Summary
Pass AWS_PROFILE as param

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35549

