### PR TITLE
Expose output for the endpoint of the elasticsearch

### DIFF
--- a/terraform/aws/modules/elasticsearch/outputs.tf
+++ b/terraform/aws/modules/elasticsearch/outputs.tf
@@ -1,0 +1,4 @@
+output "endpoint" {
+  value       = aws_elasticsearch_domain.es_domain.endpoint
+  description = "The Domain-specific endpoint used to submit index, search, and data upload requests."
+}


### PR DESCRIPTION
#### Summary
We need to use the endpoint elasticsearch is created in AWS so we can pass this
as reference to the elasticsearch provider.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35823
