### PR TITLE
Fix config cluster auth failure

### DIFF
--- a/terraform/aws/modules/cluster/providers.tf
+++ b/terraform/aws/modules/cluster/providers.tf
@@ -1,9 +1,14 @@
+data "aws_eks_cluster_auth" "cluster_auth" {
+  name = var.deployment_name
+  depends_on = [
+    aws_eks_cluster.cluster,
+    aws_autoscaling_group.worker-asg,
+    aws_iam_role.lambda_role
+  ]
+}
+
 provider "kubernetes" {
   host                   = aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(aws_eks_cluster.cluster.certificate_authority.0.data)
-  exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
-    args        = ["eks", "get-token", "--cluster-name", aws_eks_cluster.cluster.name, "--profile", var.aws_profile]
-    command     = "aws"
-  }
+  token                  = data.aws_eks_cluster_auth.cluster_auth.token
 }


### PR DESCRIPTION
#### Summary
If this commit applied accompanied with upgrade of kubernetes provider to 2.2.0 and aws provider to 3.39.0 will fix the cluster authentication issues.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-35830

