### PR TITLE
Add cost explorer permissions to workers

### DIFF
--- a/terraform/aws/modules/cluster/worker_iam.tf
+++ b/terraform/aws/modules/cluster/worker_iam.tf
@@ -101,6 +101,31 @@ resource "aws_iam_policy" "cluster_autoscaler_policy" {
 EOF
 }
 
+resource "aws_iam_policy" "cost_explorer_policy" {
+  name        = "cloud-${var.cluster_short_name}-cost-explorer-policy"
+  path        = "/"
+  description = "Policy for cost explorer required permissions."
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "ce:*",
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "worker_cost_explorer_policy" {
+  policy_arn = aws_iam_policy.cost_explorer_policy.arn
+  role       = aws_iam_role.worker-role.name
+}
+
 resource "aws_iam_role_policy_attachment" "worker_cluster_autoscaler_policy" {
   policy_arn = aws_iam_policy.cluster_autoscaler_policy.arn
   role       = aws_iam_role.worker-role.name


### PR DESCRIPTION
If this commit applied workers ant their pods will be able to do AWS cost Explorer API calls
Issue: MM-36029

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add cost explorer permissions to workers

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36029

