### PR TITLE
Add volume size & type as variables to bind servers

### DIFF
--- a/terraform/aws/modules/bind-server/bind-servers.tf
+++ b/terraform/aws/modules/bind-server/bind-servers.tf
@@ -53,12 +53,19 @@ resource "aws_key_pair" "bind" {
   public_key = var.ssh_key_public
 }
 
-resource "aws_launch_configuration" "bind_lauch_configuration" {
+resource "aws_launch_configuration" "bind_launch_configuration" {
   name_prefix     = "${var.name}-"
   image_id        = var.ami
   instance_type   = var.instance_type
   key_name        = "mattermost-cloud-${var.environment}-bind"
   security_groups = [aws_security_group.bind_sg.id]
+
+  root_block_device {
+    volume_size           = var.volume_size
+    volume_type           = var.volume_type
+    delete_on_termination = true
+  }
+
   lifecycle {
     create_before_destroy = true
   }
@@ -66,7 +73,7 @@ resource "aws_launch_configuration" "bind_lauch_configuration" {
 
 resource "aws_autoscaling_group" "bind_autoscale" {
   name                      = "autoscale-bind-server"
-  launch_configuration      = aws_launch_configuration.bind_lauch_configuration.name
+  launch_configuration      = aws_launch_configuration.bind_launch_configuration.name
   min_size                  = 3
   max_size                  = 3
   desired_capacity          = 3

--- a/terraform/aws/modules/bind-server/variables.tf
+++ b/terraform/aws/modules/bind-server/variables.tf
@@ -41,3 +41,16 @@ variable "environment" {}
 variable "ssh_key_public" {}
 
 variable "teleport_cidr" {}
+
+variable "volume_size" {
+  description = "The size of the volume for DNS Bind Servers"
+  default     = 8
+  type        = number
+}
+
+variable "volume_type" {
+  description = "The type of the volume for DNS Bind Servers"
+  default     = "gp2"
+  type        = string
+}
+


### PR DESCRIPTION
If this commit applied bind server could have different volume size based on the needs of each use-case.
Issue: MM-36079

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add volume size & type as variables to bind servers

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36079

