### PR TITLE
Add required roles for EBS monitoring on Bind Servers

### DIFF
--- a/terraform/aws/modules/bind-server/bind-servers.tf
+++ b/terraform/aws/modules/bind-server/bind-servers.tf
@@ -54,11 +54,12 @@ resource "aws_key_pair" "bind" {
 }
 
 resource "aws_launch_configuration" "bind_launch_configuration" {
-  name_prefix     = "${var.name}-"
-  image_id        = var.ami
-  instance_type   = var.instance_type
-  key_name        = "mattermost-cloud-${var.environment}-bind"
-  security_groups = [aws_security_group.bind_sg.id]
+  iam_instance_profile = aws_iam_instance_profile.bind-server-instance-profile.name
+  name_prefix          = "${var.name}-"
+  image_id             = var.ami
+  instance_type        = var.instance_type
+  key_name             = "mattermost-cloud-${var.environment}-bind"
+  security_groups      = [aws_security_group.bind_sg.id]
 
   root_block_device {
     volume_size           = var.volume_size
@@ -117,4 +118,35 @@ resource "aws_network_interface" "bind_network_interface" {
   tags = {
     BindServer = "true"
   }
+}
+
+resource "aws_iam_instance_profile" "bind-server-instance-profile" {
+  name = "${var.environment}-bind-server-instance-profile"
+  role = aws_iam_role.bind-server-role.name
+}
+
+resource "aws_iam_role" "bind-server-role" {
+  name = "${var.environment}-bind-server-role"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}
+
+resource "aws_iam_role_policy_attachment" "bind-cloudwatch-agent" {
+  count = length(local.role_policy_arn)
+
+  role       = aws_iam_role.bind-server-role.name
+  policy_arn = element(local.role_policy_arn, count.index)
 }

--- a/terraform/aws/modules/bind-server/bind-servers.tf
+++ b/terraform/aws/modules/bind-server/bind-servers.tf
@@ -1,3 +1,7 @@
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
 # The SG of the bind server
 resource "aws_security_group" "bind_sg" {
   name        = "Bind Server SG"

--- a/terraform/aws/modules/bind-server/locals.tf
+++ b/terraform/aws/modules/bind-server/locals.tf
@@ -2,4 +2,6 @@ locals {
   role_policy_arn = [
     "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
   ]
+
+  aws_sns_topic_arn = "arn:aws:sns:us-east-1:${data.aws_caller_identity.current.account_id}:elb-alarm-topic"
 }

--- a/terraform/aws/modules/bind-server/locals.tf
+++ b/terraform/aws/modules/bind-server/locals.tf
@@ -1,0 +1,5 @@
+locals {
+  role_policy_arn = [
+    "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy",
+  ]
+}

--- a/terraform/aws/modules/bind-server/monitoring.tf
+++ b/terraform/aws/modules/bind-server/monitoring.tf
@@ -1,0 +1,44 @@
+resource "aws_cloudwatch_metric_alarm" "low_free_storage_space" {
+  for_each            = toset(var.hosts_list)
+  alarm_name          = "${var.environment}-BindServerFreeStorageSpaceTooLow-${each.key}"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "disk_used_percent"
+  namespace           = "CWAgent"
+  period              = "86400"
+  statistic           = "Average"
+  threshold           = 90.0
+  alarm_description   = "Average disk space usage is over 90% last 1 day"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+
+  dimensions = {
+    path   = "/"
+    fstype = "ext4"
+    host   = each.key
+    device = "nvme0n1p1"
+  }
+
+}
+
+resource "aws_cloudwatch_metric_alarm" "low_free_memory" {
+
+  for_each            = toset(var.hosts_list)
+  alarm_name          = "${var.environment}-BindServerFreeMemoryTooLow-${each.key}"
+  comparison_operator = "LeesThanOrEqualToThreshold"
+  evaluation_periods  = "1"
+  metric_name         = "mem_available_percent"
+  namespace           = "CWAgent"
+  period              = "3600"
+  statistic           = "Average"
+  threshold           = 10.0
+  alarm_description   = "Average memory available is less than 10% last 1 hour"
+  alarm_actions       = [local.aws_sns_topic_arn]
+  ok_actions          = [local.aws_sns_topic_arn]
+  treat_missing_data  = "ignore"
+
+  dimensions = {
+    host = each.key
+  }
+}

--- a/terraform/aws/modules/bind-server/variables.tf
+++ b/terraform/aws/modules/bind-server/variables.tf
@@ -54,3 +54,9 @@ variable "volume_type" {
   type        = string
 }
 
+variable "hosts_list" {
+  description = "The list of bind servers hosts"
+  default     = []
+  type        = list(string)
+}
+


### PR DESCRIPTION
If this commit applied bind servers would have proper permissions to be able to monitor their volumes.
Issue: MM-36080

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
If this commit applied bind servers would have proper permissions to be able to monitor their volumes.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36080

