### PR TITLE
Adapt Gitlab Route53 to work with new k8s provider

### DIFF
--- a/terraform/aws/modules/gitlab/gitlab-route53.tf
+++ b/terraform/aws/modules/gitlab/gitlab-route53.tf
@@ -13,7 +13,7 @@ resource "aws_route53_record" "gitlab_record" {
   name    = "gitlab"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.gitlab_nginx.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.gitlab_nginx.status.0.load_balancer.0.ingress.0.hostname]
 
   depends_on = [
     helm_release.gitlab,
@@ -26,7 +26,7 @@ resource "aws_route53_record" "registry_record" {
   name    = "registry"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.gitlab_nginx.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.gitlab_nginx.status.0.load_balancer.0.ingress.0.hostname]
 
   depends_on = [
     helm_release.gitlab,


### PR DESCRIPTION
#### Summary
Adapt Gitlab Route53 to work with new k8s provider
