### PR TITLE
MM-37050 Adding tag role permission for provisioner

### DIFF
--- a/terraform/aws/modules/provisioner-users/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/provisioner-users/provisioner_user_permissions.tf
@@ -327,7 +327,8 @@ resource "aws_iam_policy" "iam" {
                 "iam:PassRole",
                 "iam:AttachRolePolicy",
                 "iam:DetachRolePolicy",
-                "iam:ListAttachedRolePolicies"
+                "iam:ListAttachedRolePolicies",
+                "iam:TagRole"
             ],
             "Resource": [
                 "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/masters.*",


### PR DESCRIPTION

#### Summary
Add permission for provisioner to allow TagRole for nodes.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-37050

