### PR TITLE
Add AWS permissions for Kops 1.21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,12 @@
 version: 2.1
 
 orbs:
-  aws-s3: circleci/aws-s3@1.0.11
+  aws-s3: circleci/aws-s3@2.0.0
 
 executors:
   default:
     docker:
-      - image: circleci/golang:1.14.2
+      - image: circleci/golang:1.16.6
     working_directory: /go/src/github.com/mattermost/mattermost-cloud-monitoring
 
 jobs:

--- a/terraform/aws/modules/provisioner-users/provisioner_user_permissions.tf
+++ b/terraform/aws/modules/provisioner-users/provisioner_user_permissions.tf
@@ -168,7 +168,7 @@ EOF
 resource "aws_iam_policy" "ec2" {
   name        = "mattermost-provisioner-ec2-policy${local.conditional_dash_region}"
   path        = "/"
-  description = "EC2 permissions for provisioner user"
+  description = "EC2, SQS, EventBridge permissions for provisioner user"
 
   policy = <<EOF
 {
@@ -249,8 +249,11 @@ resource "aws_iam_policy" "ec2" {
                 "autoscaling:SuspendProcesses",
                 "autoscaling:TerminateInstanceInAutoScalingGroup",
                 "autoscaling:CreateOrUpdateTags",
+                "autoscaling:DescribeWarmPool",
                 "acm:ListCertificates",
-                "acm:ListTagsForCertificate"
+                "acm:ListTagsForCertificate",
+                "sqs:ListQueues",
+                "events:ListRules"
             ],
             "Resource": "*"
         }
@@ -328,7 +331,8 @@ resource "aws_iam_policy" "iam" {
                 "iam:AttachRolePolicy",
                 "iam:DetachRolePolicy",
                 "iam:ListAttachedRolePolicies",
-                "iam:TagRole"
+                "iam:TagRole",
+                "iam:TagInstanceProfile"
             ],
             "Resource": [
                 "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/masters.*",


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary

If this commit applied nodes will have the permissions that new version of Kops 1.21 needs to create a new cluster.
We hit the limit of policies that can be attached so also repurposed mattermost-provisioner-ec2-policy to include any new categories needed that we don't have a specific policy for them already attached.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-37151

