### PR TITLE
[MM-36824] Enable R53 record for chaos mesh endpoint

### DIFF
--- a/terraform/aws/modules/route53-registration/route53.tf
+++ b/terraform/aws/modules/route53-registration/route53.tf
@@ -118,3 +118,11 @@ resource "aws_route53_record" "chimera" {
   ttl     = "60"
   records = [data.kubernetes_service.nginx-public.load_balancer_ingress.0.hostname]
 }
+
+resource "aws_route53_record" "chaos_mesh" {
+  zone_id = var.private_hosted_zoneid
+  name    = "chaos"
+  type    = "CNAME"
+  ttl     = "300"
+  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+}


### PR DESCRIPTION
#### Summary
- Enable R53 record for chaos mesh endpoint

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-36824
