### PR TITLE
Add variable for major_version_upgrade

### DIFF
--- a/terraform/aws/modules/awat/awat_db.tf
+++ b/terraform/aws/modules/awat/awat_db.tf
@@ -58,7 +58,7 @@ resource "aws_db_instance" "awat" {
   name                        = var.db_name
   username                    = var.db_username
   password                    = var.db_password
-  allow_major_version_upgrade = false
+  allow_major_version_upgrade = var.allow_major_version_upgrade
   auto_minor_version_upgrade  = true
   apply_immediately           = true
   backup_retention_period     = var.db_backup_retention_period

--- a/terraform/aws/modules/awat/variables.tf
+++ b/terraform/aws/modules/awat/variables.tf
@@ -46,3 +46,8 @@ variable "db_deletion_protection" {
 variable "enable_awat_bucket_restriction" {}
 
 variable "cnc_user" {}
+
+variable "allow_major_version_upgrade" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
Seems that AWS forces a major version upgrade which fails because of hardcoded false value.
Issue: MM-38045

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Seems that AWS forces a major version upgrade which fails because of hardcoded false value.


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38045

