### PR TITLE
Fix endpoint syntax to be in sync with 2.4.1 kubernetes provider

### DIFF
--- a/terraform/aws/modules/route53-registration/providers.tf
+++ b/terraform/aws/modules/route53-registration/providers.tf
@@ -10,6 +10,4 @@ provider "kubernetes" {
   host                   = data.aws_eks_cluster.cluster.endpoint
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
   token                  = data.aws_eks_cluster_auth.cluster_auth.token
-  load_config_file       = false
-  config_path            = "${var.kubeconfig_dir}/kubeconfig"
 }

--- a/terraform/aws/modules/route53-registration/route53.tf
+++ b/terraform/aws/modules/route53-registration/route53.tf
@@ -18,7 +18,7 @@ resource "aws_route53_record" "prometheus" {
   name    = "prometheus"
   type    = "CNAME"
   ttl     = "300"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "grafana" {
@@ -26,7 +26,7 @@ resource "aws_route53_record" "grafana" {
   name    = "grafana"
   type    = "CNAME"
   ttl     = "300"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "database_factory" {
@@ -34,7 +34,7 @@ resource "aws_route53_record" "database_factory" {
   name    = "dbfactory"
   type    = "CNAME"
   ttl     = "300"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "thanos" {
@@ -42,7 +42,7 @@ resource "aws_route53_record" "thanos" {
   name    = "thanos"
   type    = "CNAME"
   ttl     = "300"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "blackbox" {
@@ -50,7 +50,7 @@ resource "aws_route53_record" "blackbox" {
   name    = "blackbox"
   type    = "CNAME"
   ttl     = "300"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "argocd" {
@@ -58,7 +58,7 @@ resource "aws_route53_record" "argocd" {
   name    = "argocd"
   type    = "CNAME"
   ttl     = "300"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "provisioner" {
@@ -66,7 +66,7 @@ resource "aws_route53_record" "provisioner" {
   name    = "provisioner"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "awat" {
@@ -76,7 +76,7 @@ resource "aws_route53_record" "awat" {
   name    = "awat"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "customer_web_server" {
@@ -86,7 +86,7 @@ resource "aws_route53_record" "customer_web_server" {
   name    = "portal"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx-public.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-public.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "customer_web_server_internal" {
@@ -96,7 +96,7 @@ resource "aws_route53_record" "customer_web_server_internal" {
   name    = "portal"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "customer_web_server_api_internal" {
@@ -106,7 +106,7 @@ resource "aws_route53_record" "customer_web_server_api_internal" {
   name    = "api"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "chimera" {
@@ -116,7 +116,7 @@ resource "aws_route53_record" "chimera" {
   name    = "chimera"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx-public.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-public.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "chaos_mesh" {
@@ -124,7 +124,7 @@ resource "aws_route53_record" "chaos_mesh" {
   name    = "chaos"
   type    = "CNAME"
   ttl     = "300"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }
 
 resource "aws_route53_record" "kubecost" {
@@ -134,5 +134,5 @@ resource "aws_route53_record" "kubecost" {
   name    = "kubecost"
   type    = "CNAME"
   ttl     = "60"
-  records = [data.kubernetes_service.nginx-private.load_balancer_ingress.0.hostname]
+  records = [data.kubernetes_service.nginx-private.status.0.load_balancer.0.ingress.0.hostname]
 }


### PR DESCRIPTION
Issue: MM-38444

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix endpoint syntax to be in sync with 2.4.1 kubernetes provider

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-38444

