### PR TITLE
Add module for chaos engine

### DIFF
--- a/terraform/aws/modules/chaos-engine/README.md
+++ b/terraform/aws/modules/chaos-engine/README.md
@@ -1,0 +1,55 @@
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_terraform"></a> [terraform](#provider\_terraform) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_db_instance.chaos_engine](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_instance) | resource |
+| [aws_db_subnet_group.subnets_db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
+| [aws_security_group.cec_to_postgres](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [terraform_remote_state.cluster](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_allocated_db_storage"></a> [allocated\_db\_storage](#input\_allocated\_db\_storage) | The allocated storage in gigabytes for the DB | `string` | `20` | no |
+| <a name="input_db_backup_retention_period"></a> [db\_backup\_retention\_period](#input\_db\_backup\_retention\_period) | The days to retain backups for | `number` | `7` | no |
+| <a name="input_db_backup_window"></a> [db\_backup\_window](#input\_db\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | `"12:01-12:31"` | no |
+| <a name="input_db_deletion_protection"></a> [db\_deletion\_protection](#input\_db\_deletion\_protection) | n/a | `bool` | `true` | no |
+| <a name="input_db_engine_version"></a> [db\_engine\_version](#input\_db\_engine\_version) | The engine version to use | `string` | `"13.3"` | no |
+| <a name="input_db_identifier"></a> [db\_identifier](#input\_db\_identifier) | The database identifier | `string` | n/a | yes |
+| <a name="input_db_instance_class"></a> [db\_instance\_class](#input\_db\_instance\_class) | The instance type of the RDS instance | `string` | `"t2.micro"` | no |
+| <a name="input_db_maintenance_window"></a> [db\_maintenance\_window](#input\_db\_maintenance\_window) | The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00' | `string` | `"Sun:02:00-Sun:03:00"` | no |
+| <a name="input_db_master_az"></a> [db\_master\_az](#input\_db\_master\_az) | The availability zone for Master Database of provisioner | `string` | n/a | yes |
+| <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The DB name to create. If omitted, no database is created initially | `string` | n/a | yes |
+| <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Password for the master DB user. | `string` | n/a | yes |
+| <a name="input_db_username"></a> [db\_username](#input\_db\_username) | Username for the master DB user | `string` | n/a | yes |
+| <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment will run | `string` | n/a | yes |
+| <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | The list of private subnet IDs | `list(string)` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
+| <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | RDS Snapshot to restore | `string` | n/a | yes |
+| <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | n/a | `bool` | `false` | no |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC where database will run | `string` | n/a | yes |
+| <a name="input_vpn_cidr"></a> [vpn\_cidr](#input\_vpn\_cidr) | The CIDR to access VPN | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_aws_db_instance_provisioner_endpoint"></a> [aws\_db\_instance\_provisioner\_endpoint](#output\_aws\_db\_instance\_provisioner\_endpoint) | n/a |

--- a/terraform/aws/modules/chaos-engine/README.md
+++ b/terraform/aws/modules/chaos-engine/README.md
@@ -21,6 +21,8 @@ No modules.
 | [aws_db_subnet_group.subnets_db](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/db_subnet_group) | resource |
 | [aws_security_group.cec_to_postgres](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_eks_cluster.cluster](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster) | data source |
+| [aws_eks_cluster_auth.cluster_auth](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/eks_cluster_auth) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [terraform_remote_state.cluster](https://registry.terraform.io/providers/hashicorp/terraform/latest/docs/data-sources/remote_state) | data source |
 
@@ -29,6 +31,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_allocated_db_storage"></a> [allocated\_db\_storage](#input\_allocated\_db\_storage) | The allocated storage in gigabytes for the DB | `string` | `20` | no |
+| <a name="input_cloud_vpn_cidr"></a> [cloud\_vpn\_cidr](#input\_cloud\_vpn\_cidr) | The CIDR to access VPN | `list(string)` | n/a | yes |
 | <a name="input_db_backup_retention_period"></a> [db\_backup\_retention\_period](#input\_db\_backup\_retention\_period) | The days to retain backups for | `number` | `7` | no |
 | <a name="input_db_backup_window"></a> [db\_backup\_window](#input\_db\_backup\_window) | The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance\_window | `string` | `"12:01-12:31"` | no |
 | <a name="input_db_deletion_protection"></a> [db\_deletion\_protection](#input\_db\_deletion\_protection) | n/a | `bool` | `true` | no |
@@ -40,13 +43,13 @@ No modules.
 | <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The DB name to create. If omitted, no database is created initially | `string` | n/a | yes |
 | <a name="input_db_password"></a> [db\_password](#input\_db\_password) | Password for the master DB user. | `string` | n/a | yes |
 | <a name="input_db_username"></a> [db\_username](#input\_db\_username) | Username for the master DB user | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The deployment name related to k8s cluster | `string` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment will run | `string` | n/a | yes |
 | <a name="input_private_subnets"></a> [private\_subnets](#input\_private\_subnets) | The list of private subnet IDs | `list(string)` | n/a | yes |
 | <a name="input_region"></a> [region](#input\_region) | n/a | `any` | n/a | yes |
 | <a name="input_snapshot_identifier"></a> [snapshot\_identifier](#input\_snapshot\_identifier) | RDS Snapshot to restore | `string` | n/a | yes |
 | <a name="input_storage_encrypted"></a> [storage\_encrypted](#input\_storage\_encrypted) | n/a | `bool` | `false` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of the VPC where database will run | `string` | n/a | yes |
-| <a name="input_vpn_cidr"></a> [vpn\_cidr](#input\_vpn\_cidr) | The CIDR to access VPN | `string` | n/a | yes |
 
 ## Outputs
 

--- a/terraform/aws/modules/chaos-engine/locals.tf
+++ b/terraform/aws/modules/chaos-engine/locals.tf
@@ -10,3 +10,7 @@ data "terraform_remote_state" "cluster" {
     region = "us-east-1"
   }
 }
+
+locals {
+  timestamp_now           = formatdate("YYYY-MM-DD-hh-mm", timestamp())
+}

--- a/terraform/aws/modules/chaos-engine/locals.tf
+++ b/terraform/aws/modules/chaos-engine/locals.tf
@@ -1,0 +1,12 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+data "terraform_remote_state" "cluster" {
+  backend = "s3"
+  config = {
+    bucket = "terraform-cloud-monitoring-state-bucket-${var.environment}"
+    key    = "${data.aws_region.current.name}/mattermost-generic"
+    region = "us-east-1"
+  }
+}

--- a/terraform/aws/modules/chaos-engine/locals.tf
+++ b/terraform/aws/modules/chaos-engine/locals.tf
@@ -6,11 +6,11 @@ data "terraform_remote_state" "cluster" {
   backend = "s3"
   config = {
     bucket = "terraform-cloud-monitoring-state-bucket-${var.environment}"
-    key    = "${data.aws_region.current.name}/mattermost-generic"
+    key    = "mattermost-cloud-gitlab"
     region = "us-east-1"
   }
 }
 
 locals {
-  timestamp_now           = formatdate("YYYY-MM-DD-hh-mm", timestamp())
+  timestamp_now = formatdate("YYYY-MM-DD-hh-mm", timestamp())
 }

--- a/terraform/aws/modules/chaos-engine/main.tf
+++ b/terraform/aws/modules/chaos-engine/main.tf
@@ -62,7 +62,7 @@ resource "aws_db_instance" "chaos_engine" {
   backup_retention_period     = var.db_backup_retention_period
   backup_window               = var.db_backup_window
   db_subnet_group_name        = aws_db_subnet_group.subnets_db.name
-  vpc_security_group_ids      = [aws_security_group.cec_to_postgress.id]
+  vpc_security_group_ids      = [aws_security_group.cec_to_postgres.id]
   deletion_protection         = var.db_deletion_protection
   final_snapshot_identifier   = "chaos-engine-final-${var.db_name}-${local.timestamp_now}"
   skip_final_snapshot         = false

--- a/terraform/aws/modules/chaos-engine/main.tf
+++ b/terraform/aws/modules/chaos-engine/main.tf
@@ -1,0 +1,86 @@
+resource "aws_security_group" "cec_to_postgres" {
+  name                   = "cec_to_postgress"
+  description            = "Allow K8s C&C to access RDS Postgres"
+  vpc_id                 = var.vpc_id
+  revoke_rules_on_delete = true
+
+  ingress {
+    from_port       = 5432
+    to_port         = 5432
+    protocol        = "tcp"
+    security_groups = [data.terraform_remote_state.cluster.outputs.workers_security_group]
+  }
+
+  ingress {
+    from_port   = 5432
+    to_port     = 5432
+    protocol    = "tcp"
+    cidr_blocks = var.cloud_vpn_cidr
+    description = "cloud VPN"
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  tags = {
+    Name    = "Chaos-Engine DB SG"
+    Created = formatdate("DD MMM YYYY hh:mm ZZZ", timestamp())
+  }
+
+  lifecycle {
+    ignore_changes = [
+      tags,
+    ]
+  }
+}
+
+resource "aws_db_subnet_group" "subnets_db" {
+  name       = "chaos_engine_db_subnetgroup"
+  subnet_ids = var.private_subnets
+
+  tags = {
+    Name = "Chaos-Engine DB subnet group"
+  }
+}
+
+resource "aws_db_instance" "chaos_engine" {
+  identifier                  = var.db_identifier
+  allocated_storage           = var.allocated_db_storage
+  storage_type                = "gp2"
+  engine                      = "postgres"
+  engine_version              = var.db_engine_version
+  instance_class              = var.db_instance_class
+  name                        = var.db_name
+  username                    = var.db_username
+  password                    = var.db_password
+  allow_major_version_upgrade = false
+  auto_minor_version_upgrade  = true
+  apply_immediately           = true
+  backup_retention_period     = var.db_backup_retention_period
+  backup_window               = var.db_backup_window
+  db_subnet_group_name        = aws_db_subnet_group.subnets_db.name
+  vpc_security_group_ids      = [aws_security_group.cec_to_postgress.id]
+  deletion_protection         = var.db_deletion_protection
+  final_snapshot_identifier   = "chaos-engine-final-${var.db_name}-${local.timestamp_now}"
+  skip_final_snapshot         = false
+  maintenance_window          = var.db_maintenance_window
+  publicly_accessible         = false
+  snapshot_identifier         = var.snapshot_identifier
+  storage_encrypted           = var.storage_encrypted
+  availability_zone           = var.db_master_az
+
+  tags = {
+    Name         = "Chaos-Engine"
+    Environment  = var.environment
+    DatabaseType = "chaos-engine"
+  }
+
+  lifecycle {
+    ignore_changes = [
+      final_snapshot_identifier,
+    ]
+  }
+}

--- a/terraform/aws/modules/chaos-engine/main.tf
+++ b/terraform/aws/modules/chaos-engine/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "cec_to_postgres" {
     from_port       = 5432
     to_port         = 5432
     protocol        = "tcp"
-    security_groups = [data.terraform_remote_state.cluster.outputs.worker_security_group]
+    security_groups = [data.terraform_remote_state.cluster.outputs.workers_security_group]
   }
 
   ingress {

--- a/terraform/aws/modules/chaos-engine/main.tf
+++ b/terraform/aws/modules/chaos-engine/main.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "cec_to_postgres" {
     from_port       = 5432
     to_port         = 5432
     protocol        = "tcp"
-    security_groups = [data.terraform_remote_state.cluster.outputs.workers_security_group]
+    security_groups = [data.terraform_remote_state.cluster.outputs.worker_security_group]
   }
 
   ingress {

--- a/terraform/aws/modules/chaos-engine/outputs.tf
+++ b/terraform/aws/modules/chaos-engine/outputs.tf
@@ -1,0 +1,3 @@
+output "aws_db_instance_provisioner_endpoint" {
+  value = aws_db_instance.chaos_engine.endpoint
+}

--- a/terraform/aws/modules/chaos-engine/providers.tf
+++ b/terraform/aws/modules/chaos-engine/providers.tf
@@ -1,0 +1,22 @@
+data "aws_eks_cluster_auth" "cluster_auth" {
+  name = var.deployment_name
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = var.deployment_name
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster_auth.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster_auth.token
+    load_config_file       = false
+  }
+}

--- a/terraform/aws/modules/chaos-engine/variables.tf
+++ b/terraform/aws/modules/chaos-engine/variables.tf
@@ -1,0 +1,103 @@
+variable "environment" {
+  description = "The name of the environment will run"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "The ID of the VPC where database will run"
+  type        = string
+}
+
+variable "region" {}
+
+variable "vpn_cidr" {
+  description = "The CIDR to access VPN"
+  type        = string
+}
+
+variable "db_identifier" {
+  description = "The database identifier"
+  type        = string
+}
+
+variable "allocated_db_storage" {
+  default     = 20
+  description = "The allocated storage in gigabytes for the DB"
+  type        = string
+
+}
+
+variable "db_engine_version" {
+  default     = "13.3"
+  description = "The engine version to use"
+  type        = string
+}
+
+variable "db_instance_class" {
+  default     = "t2.micro"
+  description = "The instance type of the RDS instance"
+  type        = string
+}
+
+variable "db_master_az" {
+  description = "The availability zone for Master Database of provisioner"
+  type        = string
+}
+
+variable "db_name" {
+  description = "The DB name to create. If omitted, no database is created initially"
+  type        = string
+}
+
+variable "db_username" {
+  description = "Username for the master DB user"
+  type        = string
+
+}
+
+variable "db_password" {
+  description = "Password for the master DB user."
+  type        = string
+
+}
+
+variable "db_backup_retention_period" {
+  default     = 7
+  description = "The days to retain backups for"
+  type        = number
+
+}
+
+variable "db_backup_window" {
+  default     = "12:01-12:31"
+  description = "The daily time range (in UTC) during which automated backups are created if they are enabled. Example: '09:46-10:16'. Must not overlap with maintenance_window"
+  type        = string
+
+}
+
+variable "db_maintenance_window" {
+  default     = "Sun:02:00-Sun:03:00"
+  description = "The window to perform maintenance in. Syntax: 'ddd:hh24:mi-ddd:hh24:mi'. Eg: 'Mon:00:00-Mon:03:00'"
+  type        = string
+}
+
+variable "snapshot_identifier" {
+  description = "RDS Snapshot to restore"
+  type        = string
+
+}
+
+variable "storage_encrypted" {
+  default = false
+  type    = bool
+}
+
+variable "private_subnets" {
+  description = "The list of private subnet IDs"
+  type        = list(string)
+}
+
+variable "db_deletion_protection" {
+  type    = bool
+  default = true
+}

--- a/terraform/aws/modules/chaos-engine/variables.tf
+++ b/terraform/aws/modules/chaos-engine/variables.tf
@@ -1,3 +1,8 @@
+variable "deployment_name" {
+  description = "The deployment name related to k8s cluster"
+  type        = string
+}
+
 variable "environment" {
   description = "The name of the environment will run"
   type        = string

--- a/terraform/aws/modules/chaos-engine/variables.tf
+++ b/terraform/aws/modules/chaos-engine/variables.tf
@@ -10,7 +10,7 @@ variable "vpc_id" {
 
 variable "region" {}
 
-variable "vpn_cidr" {
+variable "cloud_vpn_cidr" {
   description = "The CIDR to access VPN"
   type        = string
 }

--- a/terraform/aws/modules/chaos-engine/variables.tf
+++ b/terraform/aws/modules/chaos-engine/variables.tf
@@ -12,7 +12,7 @@ variable "region" {}
 
 variable "cloud_vpn_cidr" {
   description = "The CIDR to access VPN"
-  type        = string
+  type        = list(string)
 }
 
 variable "db_identifier" {

--- a/terraform/aws/modules/customer-web-server/web-server.tf
+++ b/terraform/aws/modules/customer-web-server/web-server.tf
@@ -19,7 +19,7 @@ resource "aws_security_group" "cws_postgres_sg" {
     from_port       = 5432
     to_port         = 5432
     protocol        = "tcp"
-    security_groups = [data.terraform_remote_state.cluster.outputs.workers_security_group]
+    security_groups = [data.terraform_remote_state.cluster.output.workers_security_group]
   }
 
   ingress {


### PR DESCRIPTION
#### Summary
The chaos engine module refers the infra needed for the Mattermost Applications
[chaos engine](https://github.com/mattermost/mattermost-app-chaosengine).

#### Ticket Link
Ticket: https://mattermost.atlassian.net/browse/MM-38884
