### PR TITLE
Increase evaluation period from 1 to 4 minutes

### DIFF
--- a/terraform/aws/modules/elasticsearch/monitoring.tf
+++ b/terraform/aws/modules/elasticsearch/monitoring.tf
@@ -23,13 +23,13 @@ resource "aws_cloudwatch_metric_alarm" "cluster_status_is_yellow" {
   count               = var.monitor_cluster_status_is_yellow ? 1 : 0
   alarm_name          = "${var.alarm_name_prefix}ElasticSearch-ClusterStatusIsYellow${var.alarm_name_postfix}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods  = "1"
+  evaluation_periods  = "2"
   metric_name         = "ClusterStatus.yellow"
   namespace           = "AWS/ES"
-  period              = "60"
+  period              = "120"
   statistic           = "Maximum"
   threshold           = "1"
-  alarm_description   = "Average elasticsearch cluster status is in yellow over last 1 minutes"
+  alarm_description   = "Average elasticsearch cluster status is in yellow over last 4 minutes"
   alarm_actions       = [local.aws_sns_topic_arn]
   ok_actions          = [local.aws_sns_topic_arn]
   treat_missing_data  = "ignore"


### PR DESCRIPTION
Currently at some known heavy operations cluster goes to yellow state. Usually this doesn't need to take action as it gets self-healed. Increasing the evaluation period to avoid non actionable alerts.
Issue: MM-39127

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Increase evaluation period from 1 to 4 minutes

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39127

