### PR TITLE
Add lambda to ship Cloudwatch logs to Opensearch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,16 @@ workflows:
       - push-lambda:
           file_dir: $(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/
           bucket_name: releases.mattermost.com
+          lambda_function: logs-to-opensearch
+          zip_file_name: logs-to-opensearch.zip
+          context: mattermost-release-s3
+          filters:
+            branches:
+              only:
+                - master
+      - push-lambda:
+          file_dir: $(echo "${CIRCLE_BRANCH}" | sed 's/pull\//PR-/g')/
+          bucket_name: releases.mattermost.com
           lambda_function: deckhand
           zip_file_name: main.zip
           context: mattermost-release-s3
@@ -177,6 +187,16 @@ workflows:
           bucket_name: pr-builds.mattermost.com
           lambda_function: deckhand
           zip_file_name: main.zip
+          context: mattermost-ci-pr-builds-s3
+          filters:
+            branches:
+              ignore:
+                - master
+      - push-lambda:
+          file_dir: commit/${CIRCLE_SHA1}/
+          bucket_name: pr-builds.mattermost.com
+          lambda_function: logs-to-opensearch
+          zip_file_name: logs-to-opensearch.zip
           context: mattermost-ci-pr-builds-s3
           filters:
             branches:

--- a/lambda-functions/logs-to-opensearch/Makefile
+++ b/lambda-functions/logs-to-opensearch/Makefile
@@ -1,0 +1,14 @@
+HANDLER ?= logs-to-opensearch
+PACKAGE ?= $(HANDLER)
+
+all: pack
+
+pack:
+	@echo "Packing files..."
+	@zip $(PACKAGE).zip ../$(HANDLER)/*.js
+
+clean:
+	@echo "Cleaning up..."
+	@rm -rf $(PACKAGE).zip
+
+.PHONY: all pack clean

--- a/lambda-functions/logs-to-opensearch/index.js
+++ b/lambda-functions/logs-to-opensearch/index.js
@@ -24,7 +24,7 @@ exports.handler = function (input, context) {
         const awslogsData = JSON.parse(buffer.toString('utf8'));
 
         // transform the input to Elasticsearch documents
-        let elasticsearchBulkData = transform(awslogsData);
+        const elasticsearchBulkData = transform(awslogsData);
 
         // skip control messages
         if (!elasticsearchBulkData) {

--- a/lambda-functions/logs-to-opensearch/index.js
+++ b/lambda-functions/logs-to-opensearch/index.js
@@ -1,0 +1,269 @@
+const https = require('https');
+const zlib = require('zlib');
+const crypto = require('crypto');
+
+const endpoint = process.env.es_endpoint;
+
+// Set this to true if you want to debug why data isn't making it to
+// your Elasticsearch cluster. This will enable logging of failed items
+// to CloudWatch Logs.
+const logFailedResponses = false;
+
+exports.handler = function (input, context) {
+    // decode input from base64
+    let zippedInput = new Buffer.from(input.awslogs.data, 'base64');
+
+    // decompress the input
+    zlib.gunzip(zippedInput, function (error, buffer) {
+        if (error) {
+            context.fail(error);
+            return;
+        }
+
+        // parse the input from JSON
+        let awslogsData = JSON.parse(buffer.toString('utf8'));
+
+        // transform the input to Elasticsearch documents
+        let elasticsearchBulkData = transform(awslogsData);
+
+        // skip control messages
+        if (!elasticsearchBulkData) {
+            console.log('Received a control message');
+            context.succeed('Control message handled successfully');
+            return;
+        }
+
+        // post documents to the Amazon Elasticsearch Service
+        post(elasticsearchBulkData, function (error, success, statusCode, failedItems) {
+            console.log('Response: ' + JSON.stringify({
+                "statusCode": statusCode
+            }));
+
+            if (error) {
+                logFailure(error, failedItems);
+                context.fail(JSON.stringify(error));
+            } else {
+                console.log('Success: ' + JSON.stringify(success));
+                context.succeed('Success');
+            }
+        });
+    });
+};
+
+function transform(payload) {
+    if (payload.messageType === 'CONTROL_MESSAGE') {
+        return null;
+    }
+
+    let bulkRequestBody = '';
+
+    payload.logEvents.forEach(function (logEvent) {
+        let timestamp = new Date(logEvent.timestamp);
+
+        // index name format: logstashcwl-YYYY.MM.DD
+        let indexName = [
+            'logstash-cwl-' + timestamp.getUTCFullYear(),              // year
+            ('0' + (timestamp.getUTCMonth() + 1)).slice(-2),  // month
+            ('0' + timestamp.getUTCDate()).slice(-2), //day
+        ].join('.');
+
+        var source = buildSource(logEvent.message, logEvent.extractedFields);
+        source['@id'] = logEvent.id;
+        source['@timestamp'] = new Date(1 * logEvent.timestamp).toISOString();
+        source['@message'] = logEvent.message;
+        source['@owner'] = payload.owner;
+        source['@log_group'] = payload.logGroup;
+        source['@log_stream'] = payload.logStream;
+
+        var action = {"index": {}};
+        action.index._index = indexName;
+        action.index._id = logEvent.id;
+
+        bulkRequestBody += [
+            JSON.stringify(action),
+            JSON.stringify(source),
+        ].join('\n') + '\n';
+    });
+    return bulkRequestBody;
+}
+
+function buildSource(message, extractedFields) {
+    let jsonSubString;
+    if (extractedFields) {
+        let source = {};
+
+        for (let key in extractedFields) {
+            if (extractedFields.hasOwnProperty(key) && extractedFields[key]) {
+                let value = extractedFields[key];
+
+                if (isNumeric(value)) {
+                    source[key] = 1 * value;
+                    continue;
+                }
+
+                jsonSubString = extractJson(value);
+                if (jsonSubString !== null) {
+                    source['$' + key] = JSON.parse(jsonSubString);
+                }
+
+                source[key] = value;
+            }
+        }
+        return source;
+    }
+
+    jsonSubString = extractJson(message);
+    if (jsonSubString !== null) {
+        return JSON.parse(jsonSubString);
+    }
+
+    return {};
+}
+
+function extractJson(message) {
+    let jsonStart = message.indexOf('{');
+    if (jsonStart < 0) return null;
+    let jsonSubString = message.substring(jsonStart);
+    return isValidJson(jsonSubString) ? jsonSubString : null;
+}
+
+function isValidJson(message) {
+    try {
+        JSON.parse(message);
+    } catch (e) {
+        return false;
+    }
+    return true;
+}
+
+function isNumeric(n) {
+    return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
+function post(body, callback) {
+    let requestParams = buildRequest(endpoint, body);
+
+    let request = https.request(requestParams, function (response) {
+        let responseBody = '';
+        response.on('data', function (chunk) {
+            responseBody += chunk;
+        });
+
+        response.on('end', function () {
+            let info = JSON.parse(responseBody);
+            let failedItems;
+            let success;
+            let error;
+
+            if (response.statusCode >= 200 && response.statusCode < 299) {
+                failedItems = info.items.filter(function (x) {
+                    return x.index.status >= 300;
+                });
+
+                success = {
+                    "attemptedItems": info.items.length,
+                    "successfulItems": info.items.length - failedItems.length,
+                    "failedItems": failedItems.length
+                };
+            }
+
+            if (response.statusCode !== 200 || info.errors === true) {
+                error = {
+                    statusCode: response.statusCode,
+                    responseBody: info
+                };
+            }
+
+            callback(error, success, response.statusCode, failedItems);
+        });
+    }).on('error', function (e) {
+        callback(e);
+    });
+    request.end(requestParams.body);
+}
+
+function buildRequest(endpoint, body) {
+    let endpointParts = endpoint.match(/^([^\.]+)\.?([^\.]*)\.?([^\.]*)\.amazonaws\.com$/);
+    let region = endpointParts[2];
+    let service = endpointParts[3];
+    let datetime = (new Date()).toISOString().replace(/[:\-]|\.\d{3}/g, '');
+    let date = datetime.substr(0, 8);
+    let kDate = hmac('AWS4' + process.env.AWS_SECRET_ACCESS_KEY, date);
+    let kRegion = hmac(kDate, region);
+    let kService = hmac(kRegion, service);
+    let kSigning = hmac(kService, 'aws4_request');
+
+    let request = {
+        host: endpoint,
+        method: 'POST',
+        path: '/_bulk',
+        body: body,
+        headers: {
+            'Content-Type': 'application/json',
+            'Host': endpoint,
+            'Content-Length': Buffer.byteLength(body),
+            'X-Amz-Security-Token': process.env.AWS_SESSION_TOKEN,
+            'X-Amz-Date': datetime
+        }
+    };
+
+    let canonicalHeaders = Object.keys(request.headers)
+        .sort(function (a, b) {
+            return a.toLowerCase() < b.toLowerCase() ? -1 : 1;
+        })
+        .map(function (k) {
+            return k.toLowerCase() + ':' + request.headers[k];
+        })
+        .join('\n');
+
+    let signedHeaders = Object.keys(request.headers)
+        .map(function (k) {
+            return k.toLowerCase();
+        })
+        .sort()
+        .join(';');
+
+    let canonicalString = [
+        request.method,
+        request.path, '',
+        canonicalHeaders, '',
+        signedHeaders,
+        hash(request.body, 'hex'),
+    ].join('\n');
+
+    let credentialString = [date, region, service, 'aws4_request'].join('/');
+
+    let stringToSign = [
+        'AWS4-HMAC-SHA256',
+        datetime,
+        credentialString,
+        hash(canonicalString, 'hex')
+    ].join('\n');
+
+    request.headers.Authorization = [
+        'AWS4-HMAC-SHA256 Credential=' + process.env.AWS_ACCESS_KEY_ID + '/' + credentialString,
+        'SignedHeaders=' + signedHeaders,
+        'Signature=' + hmac(kSigning, stringToSign, 'hex')
+    ].join(', ');
+
+    return request;
+}
+
+function hmac(key, str, encoding) {
+    return crypto.createHmac('sha256', key).update(str, 'utf8').digest(encoding);
+}
+
+function hash(str, encoding) {
+    return crypto.createHash('sha256').update(str, 'utf8').digest(encoding);
+}
+
+function logFailure(error, failedItems) {
+    if (logFailedResponses) {
+        console.log('Error: ' + JSON.stringify(error, null, 2));
+
+        if (failedItems && failedItems.length > 0) {
+            console.log("Failed Items: " +
+                JSON.stringify(failedItems, null, 2));
+        }
+    }
+}

--- a/terraform/aws/modules/cleanup-unused-images/lambdas.tf
+++ b/terraform/aws/modules/cleanup-unused-images/lambdas.tf
@@ -1,4 +1,4 @@
-# Lambda function for clenaing up old and unused images.
+# Lambda function for cleaning up old and unused images.
 resource "aws_lambda_function" "deckhand" {
   s3_bucket     = var.bucket
   s3_key        = "mattermost-cloud/deckhand/master/main.zip"

--- a/terraform/aws/modules/logs-to-opensearch/README.md
+++ b/terraform/aws/modules/logs-to-opensearch/README.md
@@ -1,0 +1,46 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.logs_to_opensearch_errors](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_iam_role.logs_to_opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.logs_to_opensearch_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_lambda_function.logs_to_opensearch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_security_group.logs_to_opensearch_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_sns_topic.logs_to_opensearch_sns_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_alarm_evaluation_periods"></a> [alarm\_evaluation\_periods](#input\_alarm\_evaluation\_periods) | The number of periods over which data is compared to the specified threshold | `number` | `1` | no |
+| <a name="input_alarm_period"></a> [alarm\_period](#input\_alarm\_period) | The period in seconds over which the specified statistic is applied | `number` | `10800` | no |
+| <a name="input_alarm_threshold"></a> [alarm\_threshold](#input\_alarm\_threshold) | The value against which the specified statistic is compared | `number` | `1` | no |
+| <a name="input_bucket"></a> [bucket](#input\_bucket) | S3 bucket where the logs-to-opensearch lambda is stored | `string` | n/a | yes |
+| <a name="input_deployment_name"></a> [deployment\_name](#input\_deployment\_name) | The name of the deployment for Lambda | `string` | n/a | yes |
+| <a name="input_es_endpoint"></a> [es\_endpoint](#input\_es\_endpoint) | The endpoint of AWS Opensearch service | `string` | n/a | yes |
+| <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | The list of the private subnet IDs are used by logs-to-opensearch lambda | `list(string)` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The region which will be used in logs-to-opensearch lamda | `string` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The ID of VPC is used by the logs-to-opensearch lamda | `string` | n/a | yes |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/terraform/aws/modules/logs-to-opensearch/cloudwatch.tf
+++ b/terraform/aws/modules/logs-to-opensearch/cloudwatch.tf
@@ -1,0 +1,31 @@
+
+resource "aws_cloudwatch_metric_alarm" "logs_to_opensearch_errors" {
+  alarm_name          = "Lambda logs-to-opensearch - Errors"
+  alarm_description   = "This lambda ships logs to AWS Opensearch Service. This alarm indicates the lambda had Errors when it was executed."
+  evaluation_periods  = "1"
+  period              = "10800"
+  threshold           = "1"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  alarm_actions       = [aws_sns_topic.logs_to_opensearch_sns_topic.arn]
+  namespace           = "AWS/Lambda"
+  treat_missing_data  = "missing"
+  statistic           = "Sum"
+  metric_name         = "Errors"
+
+  dimensions = {
+    FunctionName = "logs-to-opensearch"
+    Resource     = "logs-to-opensearch"
+  }
+
+  depends_on = [
+    aws_sns_topic.logs_to_opensearch_sns_topic
+  ]
+}
+
+resource "aws_sns_topic" "logs_to_opensearch_sns_topic" {
+  name = "logs-to-opensearch-sns-topic"
+
+  depends_on = [
+    aws_lambda_function.logs_to_opensearch
+  ]
+}

--- a/terraform/aws/modules/logs-to-opensearch/cloudwatch.tf
+++ b/terraform/aws/modules/logs-to-opensearch/cloudwatch.tf
@@ -2,9 +2,9 @@
 resource "aws_cloudwatch_metric_alarm" "logs_to_opensearch_errors" {
   alarm_name          = "Lambda logs-to-opensearch - Errors"
   alarm_description   = "This lambda ships logs to AWS Opensearch Service. This alarm indicates the lambda had Errors when it was executed."
-  evaluation_periods  = "1"
-  period              = "10800"
-  threshold           = "1"
+  evaluation_periods  = var.alarm_evaluation_periods
+  period              = var.alarm_period
+  threshold           = var.alarm_threshold
   comparison_operator = "GreaterThanOrEqualToThreshold"
   alarm_actions       = [aws_sns_topic.logs_to_opensearch_sns_topic.arn]
   namespace           = "AWS/Lambda"

--- a/terraform/aws/modules/logs-to-opensearch/iam.tf
+++ b/terraform/aws/modules/logs-to-opensearch/iam.tf
@@ -1,0 +1,55 @@
+resource "aws_iam_role" "logs_to_opensearch" {
+  name                  = "logs-to-opensearch-lambda"
+  path                  = "/"
+  force_detach_policies = false
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+
+}
+
+resource "aws_iam_role_policy" "logs_to_opensearch_policy" {
+  name = "cleanup_old_images_lambda_policy"
+  role = aws_iam_role.logs_to_opensearch.id
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        },
+        {
+        "Effect": "Allow",
+        "Action": [
+            "ec2:CreateNetworkInterface",
+            "ec2:DescribeNetworkInterfaces",
+            "ec2:DeleteNetworkInterface"
+        ],
+        "Resource": [
+            "*"
+        ]
+        }
+    ]
+}
+EOF
+
+}

--- a/terraform/aws/modules/logs-to-opensearch/lambdas.tf
+++ b/terraform/aws/modules/logs-to-opensearch/lambdas.tf
@@ -1,0 +1,40 @@
+# Lambda function for shipping cloudwatch logs to Opensearch
+resource "aws_lambda_function" "logs_to_opensearch" {
+  s3_bucket     = var.bucket
+  s3_key        = "mattermost-cloud/logs-to-opensearch/master/logs-to-opensearch.zip"
+  function_name = "deckhand"
+  description   = "Lambda"
+  role          = aws_iam_role.logs_to_opensearch.arn
+  handler       = "logs-to-opensearch"
+  runtime       = "nodejs14.x"
+  timeout       = "600"
+
+
+  environment {
+    variables = {
+      "es_endpoint"   = var.es_endpoint
+    }
+  }
+
+  vpc_config {
+    subnet_ids         = flatten(var.private_subnet_ids)
+    security_group_ids = [aws_security_group.logs_to_opensearch_sg.id]
+  }
+
+}
+resource "aws_security_group" "logs_to_opensearch_sg" {
+  name        = "${var.deployment_name}-logs-to-opensearch-sg"
+  description = "Ship Cloudwatch Logs to Opensearch"
+  vpc_id      = var.vpc_id
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name = "${var.deployment_name}-logs-to-opensearch-sg"
+  }
+}

--- a/terraform/aws/modules/logs-to-opensearch/locals.tf
+++ b/terraform/aws/modules/logs-to-opensearch/locals.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/terraform/aws/modules/logs-to-opensearch/variables.tf
+++ b/terraform/aws/modules/logs-to-opensearch/variables.tf
@@ -1,0 +1,12 @@
+variable "private_subnet_ids" {}
+
+variable "vpc_id" {}
+
+variable "deployment_name" {}
+
+variable "region" {}
+
+variable "bucket" {}
+
+variable "es_endpoint" {}
+

--- a/terraform/aws/modules/logs-to-opensearch/variables.tf
+++ b/terraform/aws/modules/logs-to-opensearch/variables.tf
@@ -1,12 +1,46 @@
-variable "private_subnet_ids" {}
+variable "private_subnet_ids" {
+  type        = list(string)
+  description = "The list of the private subnet IDs are used by logs-to-opensearch lambda"
+}
+variable "vpc_id" {
+  description = "The ID of VPC is used by the logs-to-opensearch lamda"
+  type = string
+}
 
-variable "vpc_id" {}
+variable "deployment_name" {
+  description = "The name of the deployment for Lambda"
+  type = string
+}
 
-variable "deployment_name" {}
+variable "region" {
+  description = "The region which will be used in logs-to-opensearch lamda"
+  type = string
+}
 
-variable "region" {}
+variable "bucket" {
+  description = "S3 bucket where the logs-to-opensearch lambda is stored"
+  type = string
+}
 
-variable "bucket" {}
+variable "es_endpoint" {
+  description = "The endpoint of AWS Opensearch service"
+  type = string
+}
 
-variable "es_endpoint" {}
+variable "alarm_period" {
+  default = 10800
+  description = "The period in seconds over which the specified statistic is applied"
+  type = number
+}
 
+variable "alarm_evaluation_periods" {
+  default = 1
+  description = "The number of periods over which data is compared to the specified threshold"
+  type = number
+}
+
+variable "alarm_threshold" {
+  default = 1
+  description = "The value against which the specified statistic is compared"
+  type = number
+}


### PR DESCRIPTION
Issue: MM-39482

#### Summary
Add lambda to ship Cloudwatch logs to Opensearch.
The first logs we need to expose are them from Aurora Postgres Clusters

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39842

