### PR TITLE
MM-39992 added velero module to create Bucket & related IAM role

### DIFF
--- a/terraform/aws/modules/velero/locals.tf
+++ b/terraform/aws/modules/velero/locals.tf
@@ -1,0 +1,2 @@
+data "aws_caller_identity" "current" {}
+data "aws_region" "current" {}

--- a/terraform/aws/modules/velero/variables.tf
+++ b/terraform/aws/modules/velero/variables.tf
@@ -1,0 +1,3 @@
+variable "environment" {}
+
+variable "deployment_name" {}

--- a/terraform/aws/modules/velero/velero_iam.tf
+++ b/terraform/aws/modules/velero/velero_iam.tf
@@ -1,0 +1,71 @@
+resource "aws_iam_role" "velero-role" {
+  name               = "k8s-${var.environment}-velero"
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "",
+      "Effect": "Allow",
+      "Principal": {
+         "AWS": [ "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role" ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "velero-policy" {
+  name        = "velero-policy"
+  path        = "/"
+  description = "S3 & Volume permissions for velero role"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeVolumes",
+                "ec2:DescribeSnapshots",
+                "ec2:CreateTags",
+                "ec2:CreateVolume",
+                "ec2:CreateSnapshot",
+                "ec2:DeleteSnapshot"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-velero-${var.environment}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-velero-${var.environment}"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_role_policy_attachment" "velero-policy-attach" {
+  role       = aws_iam_role.velero-role.name
+  policy_arn = aws_iam_policy.velero-policy.arn
+}

--- a/terraform/aws/modules/velero/velero_s3.tf
+++ b/terraform/aws/modules/velero/velero_s3.tf
@@ -1,0 +1,22 @@
+data "aws_kms_key" "master_s3" {
+  key_id = "alias/aws/s3"
+}
+
+resource "aws_s3_bucket" "velero_bucket" {
+  bucket = "cloud-velero-${var.environment}"
+  acl    = "private"
+
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        kms_master_key_id = data.aws_kms_key.master_s3.arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+
+  versioning {
+    enabled    = true
+    mfa_delete = false
+  }
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Terraform Module to setup Velero dependencies like Bucket to store backup/restore data , Plus IAM role for velero deployment with Kube2IAM.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-39991

