### PR TITLE
Add permissions for lambda and cloudwatch logs to database factory

### DIFF
--- a/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
+++ b/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
@@ -436,3 +436,8 @@ resource "aws_iam_role_policy_attachment" "db-factory-role-attach_autoscaling" {
   role       = aws_iam_role.db-factory-role.name
   policy_arn = aws_iam_policy.autoscaling_db_factory.arn
 }
+
+resource "aws_iam_role_policy_attachment" "db-factory-role-attach-lambda-and-logs" {
+  role       = aws_iam_role.db-factory-role.name
+  policy_arn = aws_iam_policy.lambda_and_logs_db_factory.arn
+}

--- a/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
+++ b/terraform/aws/modules/database-factory/database_factory_user_permissions.tf
@@ -277,6 +277,51 @@ resource "aws_iam_policy" "sns_db_factory" {
 EOF
 }
 
+resource "aws_iam_policy" "lambda_and_logs_db_factory" {
+  name        = "mattermost-database-factory-lambda-logs-policy"
+  path        = "/"
+  description = "Lambda and Cloudwatch logs permissions for database factory user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "lambda0",
+            "Effect": "Allow",
+            "Action": [
+                "lambda:ListFunctions",
+                "lambda:ListEventSourceMappings",
+                "lambda:GetAccountSettings",
+                "lambda:TagResource",
+                "lambda:InvokeFunction",
+                "lambda:GetLayerVersion",
+                "lambda:GetFunction",
+                "lambda:UpdateFunctionConfiguration",
+                "lambda:GetFunctionConfiguration",
+                "lambda:AddLayerVersionPermission",
+                "lambda:GetLayerVersionPolicy",
+                "lambda:RemoveLayerVersionPermission",
+                "lambda:UntagResource",
+                "lambda:GetFunctionCodeSigningConfig",
+                "lambda:UpdateFunctionCode",
+                "lambda:ListFunctionEventInvokeConfigs",
+                "lambda:AddPermission",
+                "lambda:GetFunctionConcurrency",
+                "lambda:ListTags",
+                "lambda:GetFunctionEventInvokeConfig",
+                "lambda:GetAlias",
+                "lambda:RemovePermission",
+                "lambda:GetPolicy",
+                "logs:*"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
 resource "aws_iam_user_policy_attachment" "attach_sns_db_factory" {
   for_each = toset(var.database_factory_users)
   user     = each.value
@@ -325,6 +370,12 @@ resource "aws_iam_user_policy_attachment" "attach_autoscaling_db_factory" {
   for_each   = toset(var.database_factory_users)
   user       = each.value
   policy_arn = aws_iam_policy.autoscaling_db_factory.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_lambda_and_logs_db_factory" {
+  for_each   = toset(var.database_factory_users)
+  user       = each.value
+  policy_arn = aws_iam_policy.lambda_and_logs_db_factory.arn
 }
 
 resource "aws_iam_role" "db-factory-role" {


### PR DESCRIPTION
Issue: MM-40164

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add permissions for lambda and cloudwatch logs to database factory

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-40164

