### PR TITLE
[vpc-setup] Add an extra policy for velero permissions

### DIFF
--- a/aws/vpc-setup/cluster_nodes_iam.tf
+++ b/aws/vpc-setup/cluster_nodes_iam.tf
@@ -61,7 +61,7 @@ resource "aws_iam_policy" "node_policy" {
 EOF
 }
 
-resource "aws_iam_policy" "node_policy" {
+resource "aws_iam_policy" "velero_node_policy" {
   count       = var.deploy_node_policy ? 1 : 0
   name        = "cloud-provisioning-node-policy-velero${local.conditional_dash_region}"
   path        = "/"

--- a/aws/vpc-setup/cluster_nodes_iam.tf
+++ b/aws/vpc-setup/cluster_nodes_iam.tf
@@ -60,3 +60,52 @@ resource "aws_iam_policy" "node_policy" {
 }
 EOF
 }
+
+resource "aws_iam_policy" "node_policy" {
+  count       = var.deploy_node_policy ? 1 : 0
+  name        = "cloud-provisioning-node-policy-velero${local.conditional_dash_region}"
+  path        = "/"
+  description = "Provisioning custom node policy"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeVolumes",
+                "ec2:DescribeSnapshots",
+                "ec2:CreateTags",
+                "ec2:CreateVolume",
+                "ec2:CreateSnapshot",
+                "ec2:DeleteSnapshot"
+            ],
+            "Resource": "*"
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutObject",
+                "s3:AbortMultipartUpload",
+                "s3:ListMultipartUploadParts"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-velero-${var.enviornment}/*"
+            ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket"
+            ],
+            "Resource": [
+                "arn:aws:s3:::cloud-velero-${var.enviornment}"
+            ]
+        }
+    ]
+}
+EOF
+}

--- a/aws/vpc-setup/cluster_nodes_iam.tf
+++ b/aws/vpc-setup/cluster_nodes_iam.tf
@@ -93,7 +93,7 @@ resource "aws_iam_policy" "velero_node_policy" {
                 "s3:ListMultipartUploadParts"
             ],
             "Resource": [
-                "arn:aws:s3:::cloud-velero-${var.enviornment}/*"
+                "arn:aws:s3:::cloud-velero-${var.environment}/*"
             ]
         },
         {
@@ -102,7 +102,7 @@ resource "aws_iam_policy" "velero_node_policy" {
                 "s3:ListBucket"
             ],
             "Resource": [
-                "arn:aws:s3:::cloud-velero-${var.enviornment}"
+                "arn:aws:s3:::cloud-velero-${var.environment}"
             ]
         }
     ]


### PR DESCRIPTION
#### Summary
This is a temporary solution we really need to invest time to have one single point of
infrastructure as a code for cluster creation. Right now is not clear where is this going
to be attached but in practice is attached in Provisioner codebase. Check this file and
specifically this line [here](https://github.com/mattermost/mattermost-cloud/blob/master/internal/provisioner/kops_provisioner_cluster.go#L208). There are extra lines like this.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-998

#### Release Note
```release-note
Update VPC setup with extra node policy
```
