### PR TITLE
Fix a permission for velero list objects

### DIFF
--- a/aws/vpc-setup/cluster_nodes_iam.tf
+++ b/aws/vpc-setup/cluster_nodes_iam.tf
@@ -90,6 +90,7 @@ resource "aws_iam_policy" "velero_node_policy" {
                 "s3:DeleteObject",
                 "s3:PutObject",
                 "s3:AbortMultipartUpload",
+                "s3:ListBucket".
                 "s3:ListMultipartUploadParts"
             ],
             "Resource": [


### PR DESCRIPTION
#### Summary
The documentation in Velero is wrong and misses one permission which is needed for listing
the objects. This is related to [this](https://aws.amazon.com/premiumsupport/knowledge-center/s3-access-denied-listobjects-sync/)

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-2450

#### Release Note
```release-note
NONE
```
