### PR TITLE
Add conditional on test env to not create elb cloudwatch alarm

### DIFF
--- a/aws/cloudwatch-alarms/cloudwatch-alarms.tf
+++ b/aws/cloudwatch-alarms/cloudwatch-alarms.tf
@@ -115,7 +115,7 @@ resource "aws_iam_role_policy" "lambda_policy_create_elb_cloudwatch_alarm" {
   count = var.environment == "test" ? 0 : 1
 
   name = "create_elb_cloudwatch_alarm_policy"
-  role = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.id
+  role = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm[0].id
 
   policy = <<EOF
 {
@@ -147,7 +147,7 @@ resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole_create" {
   count = var.environment == "test" ? 0 : 1
 
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-  role       = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.name
+  role       = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm[0].name
 }
 
 resource "aws_lambda_function" "create_elb_cloudwatch_alarm" {
@@ -156,14 +156,14 @@ resource "aws_lambda_function" "create_elb_cloudwatch_alarm" {
   s3_bucket     = "releases.mattermost.com"
   s3_key        = "mattermost-cloud/create-elb-cloudwatch-alarm/master/main.zip"
   function_name = "create-elb-cloudwatch-alarm"
-  role          = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.arn
+  role          = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm[0].arn
   handler       = "main"
   timeout       = 120
   runtime       = "go1.x"
 
   environment {
     variables = {
-      SNS_TOPIC = aws_sns_topic.elb_alarm_topic.arn,
+      SNS_TOPIC = aws_sns_topic.elb_alarm_topic[0].arn,
     }
   }
 
@@ -206,9 +206,9 @@ resource "aws_cloudwatch_event_rule" "lb_updates" {
 resource "aws_cloudwatch_event_target" "lb-registration" {
   count = var.environment == "test" ? 0 : 1
 
-  rule      = aws_cloudwatch_event_rule.lb_updates.name
+  rule      = aws_cloudwatch_event_rule.lb_updates[0].name
   target_id = "create-elb-cloudwatch-alarm"
-  arn       = aws_lambda_function.create_elb_cloudwatch_alarm.arn
+  arn       = aws_lambda_function.create_elb_cloudwatch_alarm[0].arn
 
   depends_on = [
     aws_lambda_function.create_elb_cloudwatch_alarm
@@ -220,9 +220,9 @@ resource "aws_lambda_permission" "allow_cloudwatch_to_call_lb_registration" {
 
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.create_elb_cloudwatch_alarm.function_name
+  function_name = aws_lambda_function.create_elb_cloudwatch_alarm[0].function_name
   principal     = "events.amazonaws.com"
-  source_arn    = aws_cloudwatch_event_rule.lb_updates.arn
+  source_arn    = aws_cloudwatch_event_rule.lb_updates[0].arn
 
   depends_on = [
     aws_lambda_function.create_elb_cloudwatch_alarm

--- a/aws/cloudwatch-alarms/cloudwatch-alarms.tf
+++ b/aws/cloudwatch-alarms/cloudwatch-alarms.tf
@@ -163,7 +163,7 @@ resource "aws_lambda_function" "create_elb_cloudwatch_alarm" {
 
   environment {
     variables = {
-      SNS_TOPIC = aws_sns_topic.elb_alarm_topic[0].arn,
+      SNS_TOPIC = aws_sns_topic.elb_alarm_topic.arn,
     }
   }
 

--- a/aws/cloudwatch-alarms/cloudwatch-alarms.tf
+++ b/aws/cloudwatch-alarms/cloudwatch-alarms.tf
@@ -90,6 +90,8 @@ resource "aws_sns_topic_subscription" "lamba_subscriber" {
 
 // Lambda to create the Cloudwatch alarms
 resource "aws_iam_role" "lambda_role_create_elb_cloudwatch_alarm" {
+  count = var.environment == "test" ? 0 : 1
+
   name = "create_elb_cloudwatch_alarm"
 
   assume_role_policy = <<EOF
@@ -110,6 +112,8 @@ EOF
 }
 
 resource "aws_iam_role_policy" "lambda_policy_create_elb_cloudwatch_alarm" {
+  count = var.environment == "test" ? 0 : 1
+
   name = "create_elb_cloudwatch_alarm_policy"
   role = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.id
 
@@ -140,11 +144,15 @@ EOF
 }
 
 resource "aws_iam_role_policy_attachment" "AWSLambdaBasicExecutionRole_create" {
+  count = var.environment == "test" ? 0 : 1
+
   policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
   role       = aws_iam_role.lambda_role_create_elb_cloudwatch_alarm.name
 }
 
 resource "aws_lambda_function" "create_elb_cloudwatch_alarm" {
+  count = var.environment == "test" ? 0 : 1
+
   s3_bucket     = "releases.mattermost.com"
   s3_key        = "mattermost-cloud/create-elb-cloudwatch-alarm/master/main.zip"
   function_name = "create-elb-cloudwatch-alarm"
@@ -166,6 +174,8 @@ resource "aws_lambda_function" "create_elb_cloudwatch_alarm" {
 
 // Cloudwatch rule to be triggered when a LB is deleted or created
 resource "aws_cloudwatch_event_rule" "lb_updates" {
+  count = var.environment == "test" ? 0 : 1
+
   name          = "lb-registration"
   description   = "Runs when a new LB is deleted or created"
   event_pattern = <<PATTERN
@@ -194,6 +204,8 @@ resource "aws_cloudwatch_event_rule" "lb_updates" {
 }
 
 resource "aws_cloudwatch_event_target" "lb-registration" {
+  count = var.environment == "test" ? 0 : 1
+
   rule      = aws_cloudwatch_event_rule.lb_updates.name
   target_id = "create-elb-cloudwatch-alarm"
   arn       = aws_lambda_function.create_elb_cloudwatch_alarm.arn
@@ -204,6 +216,8 @@ resource "aws_cloudwatch_event_target" "lb-registration" {
 }
 
 resource "aws_lambda_permission" "allow_cloudwatch_to_call_lb_registration" {
+  count = var.environment == "test" ? 0 : 1
+
   statement_id  = "AllowExecutionFromCloudWatch"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.create_elb_cloudwatch_alarm.function_name


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This PR is preventing create elb cloudwatch alarm as it generates unnecessary alerts to the SRE team.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

Addresses https://mattermost.atlassian.net/browse/CLD-2505

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
- Remove create elb cloudwatch alarm in test environments
```
