### PR TITLE
Set ebs_optimized flag to null for cluster defaults

### DIFF
--- a/aws/cluster/variables.tf
+++ b/aws/cluster/variables.tf
@@ -110,7 +110,7 @@ variable "spot_min_size" {
 
 variable "ebs_optimized" {
   description = "If true, the launched EC2 instance will be EBS-optimized"
-  default     = false
+  default     = null
   type        = bool
 }
 

--- a/aws/cluster/worker_asg.tf
+++ b/aws/cluster/worker_asg.tf
@@ -27,7 +27,7 @@ CONFIGMAPAWSAUTH
 }
 
 module "managed_node_group" {
-  source                 = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups?ref=v1.3.2"
+  source                 = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups?ref=fix/CLD-2311-ebs"
   vpc_security_group_ids = [aws_security_group.worker-sg.id]
   volume_size            = var.node_volume_size
   volume_type            = var.node_volume_type

--- a/aws/cluster/worker_asg.tf
+++ b/aws/cluster/worker_asg.tf
@@ -27,7 +27,7 @@ CONFIGMAPAWSAUTH
 }
 
 module "managed_node_group" {
-  source                 = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups?ref=fix/CLD-2311-ebs"
+  source                 = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups?ref=v1.3.2"
   vpc_security_group_ids = [aws_security_group.worker-sg.id]
   volume_size            = var.node_volume_size
   volume_type            = var.node_volume_type

--- a/aws/eks-managed-node-groups/variables.tf
+++ b/aws/eks-managed-node-groups/variables.tf
@@ -83,7 +83,7 @@ variable "spot_min_size" {
 
 variable "ebs_optimized" {
   description = "If true, the launched EC2 instance will be EBS-optimized"
-  default     = false
+  default     = null
   type        = bool
 }
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Set ebs_optimized flag to null for cluster defaults

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Addresses https://mattermost.atlassian.net/browse/CLD-2311

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
- Set ebs_optimized flag to null for cluster defaults
```
