### PR TITLE
Fix bucket permissions for kops 1.22 upgrade

### DIFF
--- a/aws/provisioner-users/provisioner_user_permissions.tf
+++ b/aws/provisioner-users/provisioner_user_permissions.tf
@@ -94,7 +94,8 @@ resource "aws_iam_policy" "s3" {
             "Action": [
                 "s3:ListBucket",
                 "s3:GetBucketLocation",
-                "s3:GetBucketTagging"
+                "s3:GetBucketTagging",
+                "s3:GetBucketEncryption"
             ],
             "Resource": [
                 "arn:aws:s3:::mattermost-kops-state-${var.environment}${local.conditional_dash_region}",
@@ -107,6 +108,7 @@ resource "aws_iam_policy" "s3" {
                 "s3:PutObject",
                 "s3:PutObjectAcl",
                 "s3:GetObject",
+                "s3:GetObjectTagging",
                 "s3:GetObjectAcl",
                 "s3:DeleteObject",
                 "s3:GetObjectVersionAcl"
@@ -121,6 +123,7 @@ resource "aws_iam_policy" "s3" {
             "Action": [
                 "s3:ListBucket",
                 "s3:GetBucketLocation",
+                "s3:GetBucketEncryption",
                 "s3:GetBucketTagging",
                 "s3:CreateBucket",
                 "s3:PutEncryptionConfiguration",


### PR DESCRIPTION
Issue: CLD-4038

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Fix bucket permissions for kops 1.22 upgrade

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-4038

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
