### PR TITLE
Adding more granular access to elasticsearch clusters

### DIFF
--- a/aws/elasticsearch/elasticsearch.tf
+++ b/aws/elasticsearch/elasticsearch.tf
@@ -47,7 +47,7 @@ resource "aws_elasticsearch_domain" "es_domain" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": ${var.elasticsearch_access_policy_principal}
+        "AWS": ${jsonencode(var.elasticsearch_access_policy_principal)}
       },
       "Action": "es:*",
       "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"

--- a/aws/elasticsearch/elasticsearch.tf
+++ b/aws/elasticsearch/elasticsearch.tf
@@ -40,8 +40,6 @@ resource "aws_elasticsearch_domain" "es_domain" {
     "rest.action.multi.allow_explicit_index" = "true"
   }
 
-
-
   access_policies = <<CONFIG
   {
   "Version": "2012-10-17",
@@ -49,7 +47,7 @@ resource "aws_elasticsearch_domain" "es_domain" {
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "*"
+        "AWS": ${var.elasticsearch_access_policy_principal}
       },
       "Action": "es:*",
       "Resource": "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"

--- a/aws/elasticsearch/variables.tf
+++ b/aws/elasticsearch/variables.tf
@@ -185,3 +185,9 @@ variable "master_jvm_memory_pressure_threshold" {
   type        = number
   default     = 80
 }
+
+variable "elasticsearch_access_policy_principal" {
+  description = "Which AWS resources should have access to the Elasticsearch cluster"
+  type        = list(string)
+  default     = ["*"]
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Adding more granular access to elasticsearch clusters

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-4223

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Adding more granular access to elasticsearch clusters
```
