### PR TITLE
Add new permission to provisioner user for e2e test

### DIFF
--- a/aws/provisioner-users/provisioner_user_permissions.tf
+++ b/aws/provisioner-users/provisioner_user_permissions.tf
@@ -95,7 +95,8 @@ resource "aws_iam_policy" "s3" {
                 "s3:ListBucket",
                 "s3:GetBucketLocation",
                 "s3:GetBucketTagging",
-                "s3:GetBucketEncryption"
+                "s3:GetBucketEncryption",
+                "s3:ListBucketVersions"
             ],
             "Resource": [
                 "arn:aws:s3:::mattermost-kops-state-${var.environment}${local.conditional_dash_region}",
@@ -111,6 +112,7 @@ resource "aws_iam_policy" "s3" {
                 "s3:GetObjectTagging",
                 "s3:GetObjectAcl",
                 "s3:DeleteObject",
+                "s3:DeleteObjectVersion",
                 "s3:GetObjectVersionAcl"
             ],
             "Resource": [


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Add new permission to provisioner user for e2e test, found that these missing permissions didn't allow cluster deletion on kops 1.22+

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Fixes https://mattermost.atlassian.net/browse/CLD-4632

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
- Add new permission to provisioner user for e2e test
```
