### PR TITLE
Make promtail module capable to create second instance in the same account

### DIFF
--- a/aws/lambda-promtail/cloudwatch.tf
+++ b/aws/lambda-promtail/cloudwatch.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_log_group" "lambda_promtail" {
-  name              = "/aws/lambda/lambda_promtail"
+  name              = var.cloudwatch_log_group
   retention_in_days = 14
 }
 

--- a/aws/lambda-promtail/iam.tf
+++ b/aws/lambda-promtail/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "promtail_lambda" {
-  name                  = "promtail_lambda"
+  name                  = var.promtail_lambda_iam_role
   path                  = "/"
   force_detach_policies = false
 

--- a/aws/lambda-promtail/lambdas.tf
+++ b/aws/lambda-promtail/lambdas.tf
@@ -1,7 +1,7 @@
 resource "aws_lambda_function" "lambda_promtail" {
   s3_bucket     = var.bucket
   s3_key        = "mattermost-cloud/lambda-promtail/main/main.zip"
-  function_name = "lambda-promtail"
+  function_name = var.function_name
   role          = aws_iam_role.promtail_lambda.arn
   handler       = "main"
   runtime       = "go1.x"

--- a/aws/lambda-promtail/variables.tf
+++ b/aws/lambda-promtail/variables.tf
@@ -78,3 +78,18 @@ variable "include_message" {
   description = "Determines whether to include message as a Loki label when writing logs from lambda-promtail."
   default     = "false"
 }
+
+variable "promtail_lambda_iam_role" {
+  type    = string
+  default = "promtail_lambda"
+}
+
+variable "function_name" {
+  type    = string
+  default = "lambda-promtail"
+}
+
+variable "cloudwatch_log_group" {
+  type    = string
+  default = "/aws/lambda/lambda_promtail"
+}


### PR DESCRIPTION
Issue:
Signed-off-by: Stavros Foteinopoulos <stafot@gmail.com>

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Make promtail module capable to create second instance in the same account

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
