### PR TITLE
Adding depends on to user policy attachment

### DIFF
--- a/aws/provisioner-users/provisioner_user_permissions.tf
+++ b/aws/provisioner-users/provisioner_user_permissions.tf
@@ -507,54 +507,90 @@ resource "aws_iam_user_policy_attachment" "attach_tag" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.tag.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_route53" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.route53.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_rds" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.rds.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_s3" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.s3.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_secrets_manager" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.secrets_manager.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_ec2" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.ec2.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_vpc" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.vpc.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_iam" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.iam.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_kms" {
   for_each   = toset(var.provisioner_users)
   user       = each.value
   policy_arn = aws_iam_policy.kms.arn
+
+  depends_on = [
+    "aws_iam_user.provisioner_users"
+  ]
 }
 
 resource "aws_iam_user_policy_attachment" "attach_kms_awat" {


### PR DESCRIPTION
Issue: CLD-4634
Signed-off-by: Andre Leite [andrleite@gmail.com](mailto:andrleite@gmail.com)

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
It'll add depends on user creation to policy attachment to avoid errors like this:

```
Error: Error attaching policy arn:aws:iam::<redacted>:policy/mattermost-provisioner-rds-policy to IAM User andre.test-provisioner: NoSuchEntity: The user with name andre.test-provisioner cannot be found.
	status code: 404, request id: <redacted>

Error: Error attaching policy arn:aws:iam::<redacted>:policy/mattermost-provisioner-secretsmanager-policy to IAM User andre.test-provisioner: NoSuchEntity: The user with name andre.test-provisioner cannot be found.
	status code: 404, request id: <redacted>
Error: Error attaching policy arn:aws:iam::<redacted>:policy/mattermost-provisioner-ec2-policy to IAM User andre.test-provisioner: NoSuchEntity: The user with name andre.test-provisioner cannot be found.
	status code: 404, request id: <redacted>
```

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```