### PR TITLE
[CLD-4490]: Add devops-guru aws permission to dbfactory

### DIFF
--- a/aws/database-factory/README.md
+++ b/aws/database-factory/README.md
@@ -21,7 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.autoscaling_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_policy.devops-guru_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.devops_guru_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ec2_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.iam_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.kms_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -33,7 +33,7 @@ No modules.
 | [aws_iam_role.db-factory-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach-lambda-and-logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [aws_iam_role_policy_attachment.db-factory-role-attach_devops_guru](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.db-factory-role-attach_devops-guru](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_iam](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |

--- a/aws/database-factory/README.md
+++ b/aws/database-factory/README.md
@@ -1,12 +1,16 @@
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.55 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.55 |
 
 ## Modules
 
@@ -17,6 +21,7 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.autoscaling_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.devops-guru_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.ec2_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.iam_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.kms_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
@@ -28,6 +33,7 @@ No modules.
 | [aws_iam_role.db-factory-role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach-lambda-and-logs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
+| [aws_iam_role_policy_attachment.db-factory-role-attach_devops_guru](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_ec2](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_iam](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_kms](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -36,6 +42,7 @@ No modules.
 | [aws_iam_role_policy_attachment.db-factory-role-attach_secrets_manager](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.db-factory-role-attach_sns](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.attach_autoscaling_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
+| [aws_iam_user_policy_attachment.attach_devops_guru_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.attach_ec2_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.attach_iam_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_iam_user_policy_attachment.attach_kms_db_factory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
@@ -58,3 +65,4 @@ No modules.
 ## Outputs
 
 No outputs.
+<!-- END_TF_DOCS -->

--- a/aws/database-factory/database_factory_user_permissions.tf
+++ b/aws/database-factory/database_factory_user_permissions.tf
@@ -324,7 +324,7 @@ resource "aws_iam_policy" "lambda_and_logs_db_factory" {
 EOF
 }
 
-resource "aws_iam_policy" "devops-guru_db_factory" {
+resource "aws_iam_policy" "devops_guru_db_factory" {
   name = "mattermost-database-factory-devops-guru-policy"
   path = "/"
   description = "Devops Guru permissions for database factory user"
@@ -405,7 +405,7 @@ resource "aws_iam_user_policy_attachment" "attach_lambda_and_logs_db_factory" {
 resource "aws_iam_user_policy_attachment" "attach_devops_guru_db_factory" {
   for_each   = toset(var.database_factory_users)
   user       = each.value
-  policy_arn = aws_iam_policy.devops-guru_db_factory.arn
+  policy_arn = aws_iam_policy.devops_guru_db_factory.arn
 }
 
 resource "aws_iam_role" "db-factory-role" {
@@ -474,5 +474,5 @@ resource "aws_iam_role_policy_attachment" "db-factory-role-attach-lambda-and-log
 
 resource "aws_iam_role_policy_attachment" "db-factory-role-attach_devops_guru" {
   role       = aws_iam_role.db-factory-role.name
-  policy_arn = aws_iam_policy.devops-guru_db_factory.arn
+  policy_arn = aws_iam_policy.devops_guru_db_factory.arn
 }

--- a/aws/database-factory/database_factory_user_permissions.tf
+++ b/aws/database-factory/database_factory_user_permissions.tf
@@ -324,6 +324,28 @@ resource "aws_iam_policy" "lambda_and_logs_db_factory" {
 EOF
 }
 
+resource "aws_iam_policy" "devops-guru_db_factory" {
+  name = "mattermost-database-factory-devops-guru-policy"
+  path = "/"
+  description = "Devops Guru permissions for database factory user"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "DevOpsGuru0",
+            "Effect": "Allow",
+            "Action": [
+                "devops-guru:UpdateResourceCollection"
+            ],
+            "Resource": "*"
+        }
+    ]
+}
+EOF
+}
+
 resource "aws_iam_user_policy_attachment" "attach_sns_db_factory" {
   for_each = toset(var.database_factory_users)
   user     = each.value
@@ -378,6 +400,12 @@ resource "aws_iam_user_policy_attachment" "attach_lambda_and_logs_db_factory" {
   for_each   = toset(var.database_factory_users)
   user       = each.value
   policy_arn = aws_iam_policy.lambda_and_logs_db_factory.arn
+}
+
+resource "aws_iam_user_policy_attachment" "attach_devops_guru_db_factory" {
+  for_each   = toset(var.database_factory_users)
+  user       = each.value
+  policy_arn = aws_iam_policy.devops-guru_db_factory.arn
 }
 
 resource "aws_iam_role" "db-factory-role" {
@@ -442,4 +470,9 @@ resource "aws_iam_role_policy_attachment" "db-factory-role-attach_autoscaling" {
 resource "aws_iam_role_policy_attachment" "db-factory-role-attach-lambda-and-logs" {
   role       = aws_iam_role.db-factory-role.name
   policy_arn = aws_iam_policy.lambda_and_logs_db_factory.arn
+}
+
+resource "aws_iam_role_policy_attachment" "db-factory-role-attach_devops_guru" {
+  role       = aws_iam_role.db-factory-role.name
+  policy_arn = aws_iam_policy.devops-guru_db_factory.arn
 }

--- a/aws/database-factory/database_factory_user_permissions.tf
+++ b/aws/database-factory/database_factory_user_permissions.tf
@@ -472,7 +472,7 @@ resource "aws_iam_role_policy_attachment" "db-factory-role-attach-lambda-and-log
   policy_arn = aws_iam_policy.lambda_and_logs_db_factory.arn
 }
 
-resource "aws_iam_role_policy_attachment" "db-factory-role-attach_devops_guru" {
+resource "aws_iam_role_policy_attachment" "db-factory-role-attach_devops-guru" {
   role       = aws_iam_role.db-factory-role.name
   policy_arn = aws_iam_policy.devops_guru_db_factory.arn
 }

--- a/aws/database-factory/database_factory_user_permissions.tf
+++ b/aws/database-factory/database_factory_user_permissions.tf
@@ -325,8 +325,8 @@ EOF
 }
 
 resource "aws_iam_policy" "devops_guru_db_factory" {
-  name = "mattermost-database-factory-devops-guru-policy"
-  path = "/"
+  name        = "mattermost-database-factory-devops-guru-policy"
+  path        = "/"
   description = "Devops Guru permissions for database factory user"
 
   policy = <<EOF


### PR DESCRIPTION
Issue: CLD-4490
Signed-off-by: Andre Leite [andrleite@gmail.com](mailto:andrleite@gmail.com)
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add devops-guru aws permission to dbfactory

#### Ticket Link

  Fixes https://mattermost.atlassian.net/browse/CLD-4490


#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
