### PR TITLE
Add new argocd deployer role for ArgoCD cluster access

### DIFF
--- a/aws/cluster/argocd_iam.tf
+++ b/aws/cluster/argocd_iam.tf
@@ -1,0 +1,19 @@
+#############» ArgoCD Deployer IAM Role###################
+resource "aws_iam_role" "argocd-deployer" {
+  name = "ArgoCD-Deployer"
+
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+}

--- a/aws/cluster/aws_auth_configmap.tf
+++ b/aws/cluster/aws_auth_configmap.tf
@@ -2,53 +2,61 @@
 locals {
   data = var.matterwick_cluster_access_enabled == true ? {
     mapRoles = <<YAML
-  - rolearn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role"
-    username: system:node:{{EC2PrivateDNSName}}
-    groups:
-      - system:bootstrappers
-      - system:nodes
-  - rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSReservedSSO_AWSAdministratorAccess_${var.aws_reserved_sso_id}
-    username: system:masters
-    groups:
-      - eks-console-dashboard-full-access-group
-  - rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/Cloud${title(var.environment)}Admin
-    username: system:masters
-    groups:
-      - eks-console-dashboard-full-access-group
+- rolearn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role"
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+- rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSReservedSSO_AWSAdministratorAccess_${var.aws_reserved_sso_id}
+  username: system:masters
+  groups:
+    - eks-console-dashboard-full-access-group
+- rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/Cloud${title(var.environment)}Admin
+  username: system:masters
+  groups:
+    - eks-console-dashboard-full-access-group
+- rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ArgoCD-Deployer
+  username: argocd-deployer
+  groups:
+    - system:masters
   YAML
     mapUsers = <<YAML
-  - userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.matterwick_iam_user}"
-    username: "${var.matterwick_username}"
-  - userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.cnc_user}"
-    username: "${var.cnc_user}"
-    groups:
-      - system:masters
+- userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.matterwick_iam_user}"
+  username: "${var.matterwick_username}"
+- userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.cnc_user}"
+  username: "${var.cnc_user}"
+  groups:
+    - system:masters
   YAML
     } : {
     mapRoles = <<YAML
-  - rolearn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role"
-    username: system:node:{{EC2PrivateDNSName}}
-    groups:
-      - system:bootstrappers
-      - system:nodes
-  - rolearn: "${data.aws_region.current.name == "us-east-1" ? aws_iam_role.lambda_role[0].arn : data.aws_iam_role.lambda_role[0].arn}"
-    username: admin
-    groups:
-      - system:masters${local.extra_auth_config_provider}
-  - rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSReservedSSO_AWSAdministratorAccess_${var.aws_reserved_sso_id}
-    username: system:masters
-    groups:
-      - eks-console-dashboard-full-access-group
-  - rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/Cloud${title(var.environment)}Admin
-    username: system:masters
-    groups:
-      - eks-console-dashboard-full-access-group
+- rolearn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${var.deployment_name}-worker-role"
+  username: system:node:{{EC2PrivateDNSName}}
+  groups:
+    - system:bootstrappers
+    - system:nodes
+- rolearn: "${data.aws_region.current.name == "us-east-1" ? aws_iam_role.lambda_role[0].arn : data.aws_iam_role.lambda_role[0].arn}"
+  username: admin
+  groups:
+    - system:masters${local.extra_auth_config_provider}
+- rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/AWSReservedSSO_AWSAdministratorAccess_${var.aws_reserved_sso_id}
+  username: system:masters
+  groups:
+    - eks-console-dashboard-full-access-group
+- rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/Cloud${title(var.environment)}Admin
+  username: system:masters
+  groups:
+    - eks-console-dashboard-full-access-group
+- rolearn: arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/ArgoCD-Deployer
+  username: argocd-deployer
+  groups:
+    - system:masters
   YAML
     mapUsers = <<YAML
-  - userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.cnc_user}"
-    username: "${var.cnc_user}"
-    groups:
-      - system:masters
+- userarn: "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/${var.cnc_user}"
+  username: "${var.cnc_user}"
+  groups:
+    - system:masters
   YAML
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This role is needed for ArgoCD to connect to EKS clusters in other accounts. It has been tested manually as part of CLD-4881 and is now being defined in IaC. This will apply to all CnC clusters.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-4882

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
- Add ArgoCD-Deployer Role for ArgoCD access to EKS clusters.
```
