### PR TITLE
Added secret manager permission for DR Recovery policy

### DIFF
--- a/aws/iam-custom-resources/db_disaster_recovery.tf
+++ b/aws/iam-custom-resources/db_disaster_recovery.tf
@@ -23,11 +23,11 @@ resource "aws_iam_policy" "db_disaster_recovery" {
         Resource = "*"
       },
       {
-            "Action": [
-                "secretsmanager:GetSecretValue"
-            ],
-            "Effect": "Allow",
-            "Resource": local.secret_manager_rds
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ],
+        Effect   = "Allow",
+        Resource = local.secret_manager_rds
       },
     ]
   })

--- a/aws/iam-custom-resources/db_disaster_recovery.tf
+++ b/aws/iam-custom-resources/db_disaster_recovery.tf
@@ -22,6 +22,13 @@ resource "aws_iam_policy" "db_disaster_recovery" {
         Effect   = "Allow"
         Resource = "*"
       },
+      {
+            "Action": [
+                "secretsmanager:GetSecretValue"
+            ],
+            "Effect": "Allow",
+            "Resource": local.secret_manager_rds
+      },
     ]
   })
 }

--- a/aws/iam-custom-resources/local.tf
+++ b/aws/iam-custom-resources/local.tf
@@ -5,8 +5,5 @@ data "aws_region" "current" {}
 locals {
 
   secret_manager_rds = "arn:aws:secretsmanage:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret/rds-cluster-multitenant-*"
-}
 
-output "name" {
-  value = local.secret_manager_rds
 }

--- a/aws/iam-custom-resources/local.tf
+++ b/aws/iam-custom-resources/local.tf
@@ -1,0 +1,12 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}
+
+locals {
+
+  secret_manager_rds = "arn:aws:secretsmanage:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:secret/rds-cluster-multitenant-*"
+}
+
+output "name" {
+  value = local.secret_manager_rds
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Added secret manager read-only permission for db_disaster_recovery user

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-5536

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Added secret manager read-only permission for db_disaster_recovery user
```
