### PR TITLE
feat: Create RDS Cloudwatch alarms dedicated module

### DIFF
--- a/aws/rds-cloudwatch-alarms/README.md
+++ b/aws/rds-cloudwatch-alarms/README.md
@@ -1,0 +1,43 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.1.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.61.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.61.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_cloudwatch_metric_alarm.db_instances_alarm_cpu](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_cloudwatch_metric_alarm.db_instances_alarm_memory](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_metric_alarm) | resource |
+| [aws_sns_topic.aurora_cluster_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_cluster_instance_identifier"></a> [cluster\_instance\_identifier](#input\_cluster\_instance\_identifier) | The rds aurora cluster identifier to set the alerm name | `string` | `""` | no |
+| <a name="input_db_instance_identifier"></a> [db\_instance\_identifier](#input\_db\_instance\_identifier) | The rds database identifier to set the alerm name | `string` | n/a | yes |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | The rds database instance type to calculate the alarm limits | `string` | n/a | yes |
+| <a name="input_memory_alarm_limit"></a> [memory\_alarm\_limit](#input\_memory\_alarm\_limit) | Limit to trigger memory alarm. Number in Bytes (100MB) | `string` | `"100000000"` | no |
+| <a name="input_memory_cache_proportion"></a> [memory\_cache\_proportion](#input\_memory\_cache\_proportion) | Proportion of memory that is used for cache. By default it is 75%. | `number` | `0.75` | no |
+| <a name="input_ram_memory_bytes"></a> [ram\_memory\_bytes](#input\_ram\_memory\_bytes) | The RAM memory of each instance type in Bytes. | `map(any)` | <pre>{<br>  "db.m6g.large": "8589934592",<br>  "db.r5.12xlarge": "412316860416",<br>  "db.r5.16xlarge": "549755813888",<br>  "db.r5.24xlarge": "824633720832",<br>  "db.r5.2xlarge": "68719476736",<br>  "db.r5.4xlarge": "137438953472",<br>  "db.r5.8xlarge": "274877906944",<br>  "db.r5.large": "17179869184",<br>  "db.r5.xlarge": "34359738368",<br>  "db.r6g.12xlarge": "412316860416",<br>  "db.r6g.16xlarge": "549755813888",<br>  "db.r6g.24xlarge": "824633720832",<br>  "db.r6g.2xlarge": "68719476736",<br>  "db.r6g.4xlarge": "137438953472",<br>  "db.r6g.8xlarge": "274877906944",<br>  "db.r6g.large": "17179869184",<br>  "db.r6g.xlarge": "34359738368",<br>  "db.t3.large": "8589934592",<br>  "db.t3.medium": "4294967296",<br>  "db.t3.small": "2147483648",<br>  "db.t4g.large": "8589934592",<br>  "db.t4g.medium": "4294967296",<br>  "db.t4g.small": "2147483648"<br>}</pre> | no |
+| <a name="input_sns_topic"></a> [sns\_topic](#input\_sns\_topic) | The sns topic name to sent cloudwatch alarms | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to assign to the resource | `map(string)` | `{}` | no |
+
+## Outputs
+
+No outputs.
+<!-- END_TF_DOCS -->

--- a/aws/rds-cloudwatch-alarms/cloudwatch.tf
+++ b/aws/rds-cloudwatch-alarms/cloudwatch.tf
@@ -1,0 +1,62 @@
+## Cloudwatch alarms for RDS to comply with SOC2 instructions
+locals {
+  alarm_instance_identifier = var.cluster_instance_identifier == "" ? var.db_instance_identifier : var.cluster_instance_identifier
+}
+
+data "aws_sns_topic" "aurora_cluster_topic" {
+  name = var.sns_topic
+}
+
+resource "aws_cloudwatch_metric_alarm" "db_instances_alarm_cpu" {
+  alarm_name          = format("%s-cpu", local.alarm_instance_identifier)
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/RDS"
+  period              = "600"
+  statistic           = "Average"
+  threshold           = "90"
+  alarm_description   = "This metric monitors RDS DB Instance cpu utilization"
+  actions_enabled     = true
+  alarm_actions       = [data.aws_sns_topic.aurora_cluster_topic.arn]
+  dimensions          = { DBInstanceIdentifier = var.db_instance_identifier }
+
+  tags = var.tags
+}
+
+resource "aws_cloudwatch_metric_alarm" "db_instances_alarm_memory" {
+  alarm_name          = format("%s-memory", local.alarm_instance_identifier)
+  comparison_operator = "LessThanOrEqualToThreshold"
+  evaluation_periods  = "3"
+  threshold           = var.memory_alarm_limit
+  alarm_description   = "This metric monitors RDS DB Instance freeable memory"
+
+  metric_query {
+    id          = "e1"
+    expression  = "m1+${var.memory_cache_proportion}*${var.ram_memory_bytes[var.instance_type]}"
+    label       = "Total Free Memory"
+    return_data = "true"
+  }
+
+  metric_query {
+    id = "m1"
+    metric {
+      metric_name = "FreeableMemory"
+      namespace   = "AWS/RDS"
+      period      = "600"
+      stat        = "Average"
+      dimensions  = { DBInstanceIdentifier = var.db_instance_identifier }
+    }
+    return_data = "false"
+  }
+  actions_enabled = true
+  alarm_actions   = [data.aws_sns_topic.aurora_cluster_topic.arn]
+
+  lifecycle {
+    ignore_changes = [
+      metric_query
+    ]
+  }
+
+  tags = var.tags
+}

--- a/aws/rds-cloudwatch-alarms/providers.tf
+++ b/aws/rds-cloudwatch-alarms/providers.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.1.8"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.61.0"
+    }
+  }
+}

--- a/aws/rds-cloudwatch-alarms/variables.tf
+++ b/aws/rds-cloudwatch-alarms/variables.tf
@@ -1,0 +1,68 @@
+variable "cluster_instance_identifier" {
+  type        = string
+  description = "The rds aurora cluster identifier to set the alerm name"
+  default     = ""
+}
+
+variable "db_instance_identifier" {
+  type        = string
+  description = "The rds database identifier to set the alerm name"
+}
+
+variable "instance_type" {
+  type        = string
+  description = "The rds database instance type to calculate the alarm limits"
+}
+
+variable "sns_topic" {
+  type        = string
+  description = "The sns topic name to sent cloudwatch alarms"
+}
+
+variable "ram_memory_bytes" {
+  default = {
+    "db.t3.small"     = "2147483648"
+    "db.t3.medium"    = "4294967296"
+    "db.t3.large"     = "8589934592"
+    "db.t4g.small"    = "2147483648"
+    "db.t4g.medium"   = "4294967296"
+    "db.t4g.large"    = "8589934592"
+    "db.r5.large"     = "17179869184"
+    "db.r5.xlarge"    = "34359738368"
+    "db.r5.2xlarge"   = "68719476736"
+    "db.r5.4xlarge"   = "137438953472"
+    "db.r5.8xlarge"   = "274877906944"
+    "db.r5.12xlarge"  = "412316860416"
+    "db.r5.16xlarge"  = "549755813888"
+    "db.r5.24xlarge"  = "824633720832"
+    "db.m6g.large"    = "8589934592"
+    "db.r6g.large"    = "17179869184"
+    "db.r6g.xlarge"   = "34359738368"
+    "db.r6g.2xlarge"  = "68719476736"
+    "db.r6g.4xlarge"  = "137438953472"
+    "db.r6g.8xlarge"  = "274877906944"
+    "db.r6g.12xlarge" = "412316860416"
+    "db.r6g.16xlarge" = "549755813888"
+    "db.r6g.24xlarge" = "824633720832"
+  }
+  type        = map(any)
+  description = "The RAM memory of each instance type in Bytes."
+}
+
+variable "memory_alarm_limit" {
+  default     = "100000000"
+  description = "Limit to trigger memory alarm. Number in Bytes (100MB)"
+  type        = string
+}
+
+variable "memory_cache_proportion" {
+  default     = 0.75
+  description = "Proportion of memory that is used for cache. By default it is 75%."
+  type        = number
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resource"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Created cloudwatch alarm dedicated module for terragrunt use

@stafot when merged we can incorporate it in the aurora module for consistency. WDYT ? It's the same code. 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-5351

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note

```
