### PR TITLE
Adding IAM get role and instance profile permissions to provisioner for kops 1.25

### DIFF
--- a/aws/provisioner-users/provisioner_user_permissions.tf
+++ b/aws/provisioner-users/provisioner_user_permissions.tf
@@ -356,6 +356,8 @@ resource "aws_iam_policy" "iam" {
             "Sid": "iam0",
             "Effect": "Allow",
             "Action": [
+                "iam:GetRole",
+                "iam:GetInstanceProfile",
                 "iam:ListRoles",
                 "iam:ListInstanceProfiles",
                 "iam:ListRolePolicies",


### PR DESCRIPTION
#### Summary
Adding IAM get role and instance profile permissions to provisioner for kops 1.25

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6212

#### Release Note


```release-note
Adding IAM get permissions to provisioner user
```
