### PR TITLE
Add permissions needed to IAM user when custom KMS encryption exists

### DIFF
--- a/aws/vpc-setup/installation_iam_users.tf
+++ b/aws/vpc-setup/installation_iam_users.tf
@@ -89,3 +89,59 @@ resource "aws_iam_user_policy_attachment" "installation_users_attach_s3" {
   user       = aws_iam_user.installation_users[each.value]["name"]
   policy_arn = aws_iam_policy.installation_users_s3_policy[each.value]["arn"]
 }
+
+resource "aws_iam_policy" "installation_users_byok_s3_policy" {
+  for_each = var.custom_vpc_kms_keys
+
+  name        = format("%s-%s-byok", var.name, aws_vpc.vpc_creation[each.key]["id"])
+  path        = "/"
+  description = "S3 permissions for installation user with byok"
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "s3:PutObject",
+            "Resource": "${aws_s3_bucket.installation_buckets[each.key]["arn"]}/*",
+            "Condition": {
+                "StringEquals": {
+                    "s3:x-amz-server-side-encryption": "aws:kms"
+                }
+            }
+        },
+        {
+            "Sid": "VisualEditor1",
+            "Effect": "Allow",
+            "Action": [
+                "s3:PutEncryptionConfiguration",
+                "s3:GetObjectVersionTorrent",
+                "s3:PutObject",
+                "s3:GetObject",
+                "s3:GetObjectTorrent",
+                "s3:GetObjectRetention",
+                "s3:PutObjectRetention",
+                "kms:*",
+                "s3:ListBucket",
+                "s3:PutObjectLegalHold",
+                "s3:GetObjectLegalHold",
+                "s3:GetObjectVersionAttributes"
+            ],
+            "Resource": [
+                "${aws_s3_bucket.installation_buckets[each.key]["arn"]}/*",
+                "${var.custom_vpc_kms_keys[each.key]}"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_iam_user_policy_attachment" "installation_users_attach_s3_byok" {
+  for_each = var.custom_vpc_kms_keys
+
+  user       = aws_iam_user.installation_users[each.key]["name"]
+  policy_arn = aws_iam_policy.installation_users_byok_s3_policy[each.key]["arn"]
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add permissions needed to IAM user when custom KMS encryption exists

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-6288

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
