### PR TITLE
Add database_name parameter to block global cluster recreations

### DIFF
--- a/aws/rds-customer-cluster/main.tf
+++ b/aws/rds-customer-cluster/main.tf
@@ -77,6 +77,7 @@ data "aws_vpc" "provisioning_vpc_secondary" {
 resource "aws_rds_global_cluster" "global-cluster" {
   count                        = var.enable_global_cluster ? 1 : 0
   force_destroy                = true
+  database_name                = postgres
   global_cluster_identifier    = format("rds-cluster-multitenant-%s-%s", split("-", var.primary_vpc_id)[1], local.database_id)
   source_db_cluster_identifier = aws_rds_cluster.provisioning_rds_cluster_primary.arn
 }


### PR DESCRIPTION
#### Summary
- Add database_name parameter to block global cluster recreations

#### Release Note
```release-note
- Add database_name parameter to block global cluster recreations
```
