### PR TITLE
[CLD-7311] Update lambda deployments to use Pagerduty instead of Opsgenie

### DIFF
--- a/aws/cloudwatch-alarms/README.md
+++ b/aws/cloudwatch-alarms/README.md
@@ -50,8 +50,9 @@ No modules.
 | <a name="input_lambda_create_elb_s3_key"></a> [lambda\_create\_elb\_s3\_key](#input\_lambda\_create\_elb\_s3\_key) | The S3 key where the create ELB alarm lambda function is stored | `string` | n/a | yes |
 | <a name="input_lambda_create_rds_s3_key"></a> [lambda\_create\_rds\_s3\_key](#input\_lambda\_create\_rds\_s3\_key) | The S3 key where the create RDS alarm lambda function is stored | `string` | n/a | yes |
 | <a name="input_lambda_s3_bucket"></a> [lambda\_s3\_bucket](#input\_lambda\_s3\_bucket) | The S3 bucket where the lambda function is stored | `string` | n/a | yes |
-| <a name="input_opsgenie_apikey"></a> [opsgenie\_apikey](#input\_opsgenie\_apikey) | The API key for the OPSGenie integration | `string` | n/a | yes |
-| <a name="input_opsgenie_scheduler_team"></a> [opsgenie\_scheduler\_team](#input\_opsgenie\_scheduler\_team) | The opsgenie scheduler team uuid  - not used on dev | `string` | n/a | yes |
+| <a name="input_pagerduty_apikey"></a> [pagerduty\_apikey](#input\_pagerduty\_apikey) | The API key for the PagerDuty integration | `string` | n/a | yes |
+| <a name="input_pagerduty_email_address"></a> [pagerduty\_email\_address](#input\_pagerduty\_email\_address) | The PagerDuty email address to use for alerting resolves | `string` | n/a | yes |
+| <a name="input_pagerduty_integration_key"></a> [pagerduty\_integration\_key](#input\_pagerduty\_integration\_key) | The integration key for the PagerDuty integration | `string` | n/a | yes |
 
 ## Outputs
 

--- a/aws/cloudwatch-alarms/cloudwatch-alarms.tf
+++ b/aws/cloudwatch-alarms/cloudwatch-alarms.tf
@@ -57,10 +57,11 @@ resource "aws_lambda_function" "alert_elb_cloudwatch_alarm" {
 
   environment {
     variables = {
-      MATTERMOST_HOOK         = var.community_webhook
-      OPSGENIE_APIKEY         = var.opsgenie_apikey
-      OPSGENIE_SCHEDULER_TEAM = var.opsgenie_scheduler_team
-      ENVIRONMENT             = var.environment
+      MATTERMOST_HOOK           = var.community_webhook
+      PAGERDUTY_APIKEY          = var.pagerduty_apikey
+      EMAIL_ADDRESS             = var.pagerduty_email_address
+      PAGERDUTY_INTEGRATION_KEY = var.pagerduty_integration_key
+      ENVIRONMENT               = var.environment
     }
   }
 

--- a/aws/cloudwatch-alarms/example/main.tf
+++ b/aws/cloudwatch-alarms/example/main.tf
@@ -1,8 +1,7 @@
 
 module "cw_alarms" {
   source                  = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/cloudwatch-alarms?ref=v1.6.0"
-  opsgenie_apikey         = var.opsgenie_apikey
-  opsgenie_scheduler_team = var.opsgenie_scheduler_team
+  pagerduty_apikey        = var.pagerduty_apikey
   community_webhook       = var.community_webhook
   environment             = var.environment
 }

--- a/aws/cloudwatch-alarms/example/main.tf
+++ b/aws/cloudwatch-alarms/example/main.tf
@@ -1,7 +1,9 @@
 
 module "cw_alarms" {
-  source                  = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/cloudwatch-alarms?ref=v1.6.0"
-  pagerduty_apikey        = var.pagerduty_apikey
-  community_webhook       = var.community_webhook
-  environment             = var.environment
+  source                    = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/cloudwatch-alarms?ref=v1.6.0"
+  pagerduty_apikey          = var.pagerduty_apikey
+  pagerduty_email_address   = var.pagerduty_email_address
+  pagerduty_integration_key = var.pagerduty_integration_key
+  community_webhook         = var.community_webhook
+  environment               = var.environment
 }

--- a/aws/cloudwatch-alarms/example/variables.tf
+++ b/aws/cloudwatch-alarms/example/variables.tf
@@ -1,11 +1,6 @@
-variable "opsgenie_apikey" {
+variable "pagerduty_apikey" {
   type        = string
-  description = "The API key for the OPSGenie integration"
-}
-
-variable "opsgenie_scheduler_team" {
-  type        = string
-  description = "The opsgenie scheduler team uuid  - not used on dev"
+  description = "The API key for the PagerDuty integration"
 }
 
 variable "community_webhook" {

--- a/aws/cloudwatch-alarms/example/variables.tf
+++ b/aws/cloudwatch-alarms/example/variables.tf
@@ -3,6 +3,16 @@ variable "pagerduty_apikey" {
   description = "The API key for the PagerDuty integration"
 }
 
+variable "pagerduty_email_address" {
+  type        = string
+  description = "The PagerDuty email address to use for alerting resolves"
+}
+
+variable "pagerduty_integration_key" {
+  type        = string
+  description = "The integration key for the PagerDuty integration"
+}
+
 variable "community_webhook" {
   type        = string
   description = "The URL webhook to post the messages"

--- a/aws/cloudwatch-alarms/variables.tf
+++ b/aws/cloudwatch-alarms/variables.tf
@@ -1,11 +1,16 @@
-variable "opsgenie_apikey" {
+variable "pagerduty_apikey" {
   type        = string
-  description = "The API key for the OPSGenie integration"
+  description = "The API key for the PagerDuty integration"
 }
 
-variable "opsgenie_scheduler_team" {
+variable "pagerduty_email_address" {
   type        = string
-  description = "The opsgenie scheduler team uuid  - not used on dev"
+  description = "The PagerDuty email address to use for alerting resolves"
+}
+
+variable "pagerduty_integration_key" {
+  type        = string
+  description = "The integration key for the PagerDuty integration"
 }
 
 variable "community_webhook" {

--- a/aws/cloudwatch-event-alerts/README.md
+++ b/aws/cloudwatch-event-alerts/README.md
@@ -34,8 +34,7 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment | `string` | n/a | yes |
 | <a name="input_lambda_s3_bucket"></a> [lambda\_s3\_bucket](#input\_lambda\_s3\_bucket) | The S3 bucket where the lambda function is stored | `string` | n/a | yes |
 | <a name="input_lambda_s3_key"></a> [lambda\_s3\_key](#input\_lambda\_s3\_key) | The S3 key where the lambda function is stored | `string` | n/a | yes |
-| <a name="input_opsgenie_apikey"></a> [opsgenie\_apikey](#input\_opsgenie\_apikey) | The API key for the OPSGenie integration | `string` | n/a | yes |
-| <a name="input_opsgenie_scheduler_team"></a> [opsgenie\_scheduler\_team](#input\_opsgenie\_scheduler\_team) | The opsgenie scheduler team uuid  - not used on dev | `string` | n/a | yes |
+| <a name="input_pagerduty_apikey"></a> [pagerduty\_apikey](#input\_pagerduty\_apikey) | The API key for the PagerDuty integration | `string` | n/a | yes |
 
 ## Outputs
 

--- a/aws/cloudwatch-event-alerts/cloudwatch-event-alerts.tf
+++ b/aws/cloudwatch-event-alerts/cloudwatch-event-alerts.tf
@@ -37,8 +37,7 @@ resource "aws_lambda_function" "cloudwatch_event_alerts" {
   environment {
     variables = {
       MATTERMOST_HOOK         = var.community_webhook
-      OPSGENIE_APIKEY         = var.opsgenie_apikey
-      OPSGENIE_SCHEDULER_TEAM = var.opsgenie_scheduler_team
+      PAGERDUTY_APIKEY        = var.pagerduty_apikey
       ENVIRONMENT             = var.environment
     }
   }

--- a/aws/cloudwatch-event-alerts/cloudwatch-event-alerts.tf
+++ b/aws/cloudwatch-event-alerts/cloudwatch-event-alerts.tf
@@ -36,9 +36,9 @@ resource "aws_lambda_function" "cloudwatch_event_alerts" {
 
   environment {
     variables = {
-      MATTERMOST_HOOK         = var.community_webhook
-      PAGERDUTY_APIKEY        = var.pagerduty_apikey
-      ENVIRONMENT             = var.environment
+      MATTERMOST_HOOK  = var.community_webhook
+      PAGERDUTY_APIKEY = var.pagerduty_apikey
+      ENVIRONMENT      = var.environment
     }
   }
 

--- a/aws/cloudwatch-event-alerts/variables.tf
+++ b/aws/cloudwatch-event-alerts/variables.tf
@@ -1,11 +1,6 @@
-variable "opsgenie_apikey" {
+variable "pagerduty_apikey" {
   type        = string
-  description = "The API key for the OPSGenie integration"
-}
-
-variable "opsgenie_scheduler_team" {
-  type        = string
-  description = "The opsgenie scheduler team uuid  - not used on dev"
+  description = "The API key for the PagerDuty integration"
 }
 
 variable "community_webhook" {

--- a/aws/generic-webhook-notification/README.md
+++ b/aws/generic-webhook-notification/README.md
@@ -53,8 +53,7 @@ No modules.
 | <a name="input_mattermost_notification_hook"></a> [mattermost\_notification\_hook](#input\_mattermost\_notification\_hook) | n/a | `string` | n/a | yes |
 | <a name="input_mattermost_webhook_alert_prod"></a> [mattermost\_webhook\_alert\_prod](#input\_mattermost\_webhook\_alert\_prod) | n/a | `string` | n/a | yes |
 | <a name="input_mattermost_webhook_prod"></a> [mattermost\_webhook\_prod](#input\_mattermost\_webhook\_prod) | n/a | `string` | n/a | yes |
-| <a name="input_opsgenie_apikey"></a> [opsgenie\_apikey](#input\_opsgenie\_apikey) | n/a | `string` | n/a | yes |
-| <a name="input_opsgenie_scheduler_team"></a> [opsgenie\_scheduler\_team](#input\_opsgenie\_scheduler\_team) | n/a | `string` | n/a | yes |
+| <a name="input_pagerduty_apikey"></a> [pagerduty\_apikey](#input\_pagerduty\_apikey) | n/a | `string` | n/a | yes |
 | <a name="input_parent_id"></a> [parent\_id](#input\_parent\_id) | n/a | `string` | n/a | yes |
 | <a name="input_private_subnet_ids"></a> [private\_subnet\_ids](#input\_private\_subnet\_ids) | The list of the private subnet IDs are used by generic-webhook lambdas | `list(string)` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | n/a | yes |

--- a/aws/generic-webhook-notification/lambdas.tf
+++ b/aws/generic-webhook-notification/lambdas.tf
@@ -22,8 +22,7 @@ resource "aws_lambda_function" "provisioner-notification" {
     variables = {
       MATTERMOST_WEBHOOK_PROD       = var.mattermost_webhook_prod
       MATTERMOST_WEBHOOK_ALERT_PROD = var.mattermost_webhook_alert_prod
-      OPSGENIE_APIKEY               = var.opsgenie_apikey
-      OPSGENIE_SCHEDULER_TEAM       = var.opsgenie_scheduler_team
+      PAGERDUTY_APIKEY              = var.pagerduty_apikey
     }
   }
 
@@ -61,8 +60,7 @@ resource "aws_lambda_function" "elrond-notification" {
     variables = {
       MATTERMOST_ELROND_WEBHOOK_PROD = var.mattermost_elrond_webhook_prod
       MATTERMOST_WEBHOOK_ALERT_PROD  = var.mattermost_webhook_alert_prod
-      OPSGENIE_APIKEY                = var.opsgenie_apikey
-      OPSGENIE_SCHEDULER_TEAM        = var.opsgenie_scheduler_team
+      PAGERDUTY_APIKEY               = var.pagerduty_apikey
       ENVIRONMENT                    = "PROD"
     }
   }

--- a/aws/generic-webhook-notification/variables.tf
+++ b/aws/generic-webhook-notification/variables.tf
@@ -21,11 +21,7 @@ variable "mattermost_webhook_alert_prod" {
   type = string
 }
 
-variable "opsgenie_apikey" {
-  type = string
-}
-
-variable "opsgenie_scheduler_team" {
+variable "pagerduty_apikey" {
   type = string
 }
 

--- a/aws/rds-cluster-events/README.md
+++ b/aws/rds-cluster-events/README.md
@@ -35,8 +35,9 @@ No modules.
 | <a name="input_environment"></a> [environment](#input\_environment) | The name of the environment | `string` | n/a | yes |
 | <a name="input_lambda_s3_bucket"></a> [lambda\_s3\_bucket](#input\_lambda\_s3\_bucket) | The S3 bucket where the lambda function is stored | `string` | n/a | yes |
 | <a name="input_lambda_s3_key"></a> [lambda\_s3\_key](#input\_lambda\_s3\_key) | The S3 key where the lambda function is stored | `string` | n/a | yes |
-| <a name="input_opsgenie_apikey"></a> [opsgenie\_apikey](#input\_opsgenie\_apikey) | The API key for the OPSGenie integration | `string` | n/a | yes |
-| <a name="input_opsgenie_scheduler_team"></a> [opsgenie\_scheduler\_team](#input\_opsgenie\_scheduler\_team) | The opsgenie scheduler team uuid  - not used on dev | `string` | n/a | yes |
+| <a name="input_pagerduty_apikey"></a> [pagerduty\_apikey](#input\_pagerduty\_apikey) | The API key for the PagerDuty integration | `string` | n/a | yes |
+| <a name="input_pagerduty_email_address"></a> [pagerduty\_email\_address](#input\_pagerduty\_email\_address) | The PagerDuty email address to use for alerting resolves | `string` | n/a | yes |
+| <a name="input_pagerduty_integration_key"></a> [pagerduty\_integration\_key](#input\_pagerduty\_integration\_key) | The integration key for the PagerDuty integration | `string` | n/a | yes |
 
 ## Outputs
 

--- a/aws/rds-cluster-events/rds-cluster.events.tf
+++ b/aws/rds-cluster-events/rds-cluster.events.tf
@@ -36,10 +36,11 @@ resource "aws_lambda_function" "rds_cluster_events" {
 
   environment {
     variables = {
-      MATTERMOST_HOOK         = var.community_webhook
-      OPSGENIE_APIKEY         = var.opsgenie_apikey
-      OPSGENIE_SCHEDULER_TEAM = var.opsgenie_scheduler_team
-      ENVIRONMENT             = var.environment
+      MATTERMOST_HOOK           = var.community_webhook
+      PAGERDUTY_APIKEY          = var.pagerduty_apikey
+      EMAIL_ADDRESS             = var.pagerduty_email_address
+      PAGERDUTY_INTEGRATION_KEY = var.pagerduty_integration_key
+      ENVIRONMENT               = var.environment
     }
   }
 

--- a/aws/rds-cluster-events/variables.tf
+++ b/aws/rds-cluster-events/variables.tf
@@ -1,11 +1,16 @@
-variable "opsgenie_apikey" {
+variable "pagerduty_apikey" {
   type        = string
-  description = "The API key for the OPSGenie integration"
+  description = "The API key for the PagerDuty integration"
 }
 
-variable "opsgenie_scheduler_team" {
+variable "pagerduty_email_address" {
   type        = string
-  description = "The opsgenie scheduler team uuid  - not used on dev"
+  description = "The PagerDuty email address to use for alerting resolves"
+}
+
+variable "pagerduty_integration_key" {
+  type        = string
+  description = "The integration key for the PagerDuty integration"
 }
 
 variable "community_webhook" {


### PR DESCRIPTION
#### Summary
- Update lambda deployments to use Pagerduty instead of Opsgenie

#### Release Note
```release-note
- Update lambda deployments to use Pagerduty instead of Opsgenie
```
