### PR TITLE
temporary change for db upgrade

### DIFF
--- a/aws/rds-customer-cluster/main.tf
+++ b/aws/rds-customer-cluster/main.tf
@@ -449,10 +449,10 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group_postgresql_p
     value = var.password_encryption
   }
 
-  parameter {
-    name  = "rds.accepted_password_auth_method"
-    value = var.accepted_password_auth_method
-  }
+  # parameter {
+  #   name  = "rds.accepted_password_auth_method"
+  #   value = var.accepted_password_auth_method
+  # }
 
 
   tags = merge(
@@ -563,10 +563,10 @@ resource "aws_rds_cluster_parameter_group" "cluster_parameter_group_postgresql_s
     value = var.password_encryption
   }
 
-  parameter {
-    name  = "rds.accepted_password_auth_method"
-    value = var.accepted_password_auth_method
-  }
+  # parameter {
+  #   name  = "rds.accepted_password_auth_method"
+  #   value = var.accepted_password_auth_method
+  # }
 
   tags = merge(
     {

--- a/aws/rds-customer-cluster/variables.tf
+++ b/aws/rds-customer-cluster/variables.tf
@@ -256,7 +256,7 @@ variable "password_encryption" {
   description = "The password encryption method to use for the DB instance. Valid values: md5 or scram-sha-256"
 }
 
-variable "accepted_password_auth_method" {
-  type        = string
-  description = "The authentication method to use for the DB instance. Valid values: md5+scram or scram"
-}
+# variable "accepted_password_auth_method" {
+#   type        = string
+#   description = "The authentication method to use for the DB instance. Valid values: md5+scram or scram"
+# }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This is a temporary change to Upgrade RDS. We cannot apply `rds.accepted_password_auth_method` parameter before upgrade it.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
none
```
