### PR TITLE
[CLD-8072]adding new tag for vpcs

### DIFF
--- a/aws/vpc-setup/vpc.tf
+++ b/aws/vpc-setup/vpc.tf
@@ -10,6 +10,7 @@ resource "aws_vpc" "vpc_creation" {
       "Available"         = "true",
       "CloudClusterID"    = "none",
       "CloudClusterOwner" = "none",
+      "CloudClusterType"  = "kops"
       "Size"              = split("/", each.value)[1]
     },
     var.tags
@@ -20,7 +21,8 @@ resource "aws_vpc" "vpc_creation" {
       tags["Available"],
       tags["CloudClusterID"],
       tags["CloudClusterOwner"],
-      tags["CloudSecondaryClusterID"]
+      tags["CloudSecondaryClusterID"],
+      tags["CloudClusterType"]
     ]
   }
 }

--- a/aws/vpc-setup/vpc.tf
+++ b/aws/vpc-setup/vpc.tf
@@ -10,7 +10,7 @@ resource "aws_vpc" "vpc_creation" {
       "Available"         = "true",
       "CloudClusterID"    = "none",
       "CloudClusterOwner" = "none",
-      "CloudClusterType"  = "kops"
+      "CloudClusterType"  = "kops",
       "Size"              = split("/", each.value)[1]
     },
     var.tags


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

Summary
This PR will add a new tag for VPCs to identify which kind of cluster is using it. the default value is kops. More details in the ticket.

Ticket Link
Fixes https://mattermost.atlassian.net/browse/CLD-8072

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
