### PR TITLE
Set version to 1.7.5 for managed groups on eks cluster module

### DIFF
--- a/aws/eks-cluster/worker_asg.tf
+++ b/aws/eks-cluster/worker_asg.tf
@@ -27,7 +27,7 @@ CONFIGMAPAWSAUTH
 }
 
 module "managed_node_group" {
-  source                 = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups?ref=v1.6.95"
+  source                 = "github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups?ref=v1.7.5"
   vpc_security_group_ids = [aws_security_group.worker-sg.id]
   vpc_id                 = var.vpc_id
   volume_size            = var.node_volume_size


### PR DESCRIPTION
#### Summary
Set version to 1.7.5 for managed groups on eks cluster module

#### Ticket Link


#### Release Note

```release-note
Set version to 1.7.5 for managed groups on eks cluster module
```
