### PR TITLE
add security_group_referencing_support for aws_ec2_transit_gateway_vpc_attachment and setting default to disable

### DIFF
--- a/aws/transit-gateway-attachment/main.tf
+++ b/aws/transit-gateway-attachment/main.tf
@@ -1,7 +1,8 @@
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
-  subnet_ids         = var.subnet_ids
-  transit_gateway_id = var.transit_gateway_id
-  vpc_id             = var.vpc_id
+  subnet_ids                         = var.subnet_ids
+  transit_gateway_id                 = var.transit_gateway_id
+  vpc_id                             = var.vpc_id
+  security_group_referencing_support = var.security_group_referencing_support
 
   tags = {
     Name = var.name

--- a/aws/transit-gateway-attachment/variables.tf
+++ b/aws/transit-gateway-attachment/variables.tf
@@ -14,3 +14,9 @@ variable "name" {
   description = "The name tag of the tgw attachment"
   type        = string
 }
+
+variable "security_group_referencing_support" {
+  description = "Security Group Referencing allows to specify other SGs as references, or matching criterion in inbound security rules to allow instance-to-instance traffic"
+  type        = string
+  default     = "disable"
+}


### PR DESCRIPTION
#### Summary
add security_group_referencing_support for aws_ec2_transit_gateway_vpc_attachment and setting default to disable

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8152

#### Release Note


```release-note
add security_group_referencing_support for aws_ec2_transit_gateway_vpc_attachment and setting default to disable
```
