### PR TITLE
add security_group_referencing_support in tgw and add support for macos for make setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,13 @@ lint:
 
 setup:
 ## setup: install tflint
-	curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+	@if [ "$(shell uname)" = "Darwin" ]; then \
+		echo "Installing tflint using brew on macOS"; \
+		brew install tflint; \
+	else \
+		echo "Installing tflint using install script on Linux"; \
+		curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash; \
+	fi
 
 plugin:
 ## installing aws plugin for tflint

--- a/aws/transit-gateway-attachment/main.tf
+++ b/aws/transit-gateway-attachment/main.tf
@@ -1,11 +1,9 @@
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
-  subnet_ids                         = var.subnet_ids
-  transit_gateway_id                 = var.transit_gateway_id
-  vpc_id                             = var.vpc_id
-  security_group_referencing_support = var.security_group_referencing_support
+  subnet_ids         = var.subnet_ids
+  transit_gateway_id = var.transit_gateway_id
+  vpc_id             = var.vpc_id
 
   tags = {
     Name = var.name
   }
 }
-

--- a/aws/transit-gateway-attachment/main.tf
+++ b/aws/transit-gateway-attachment/main.tf
@@ -1,7 +1,8 @@
 resource "aws_ec2_transit_gateway_vpc_attachment" "this" {
-  subnet_ids         = var.subnet_ids
-  transit_gateway_id = var.transit_gateway_id
-  vpc_id             = var.vpc_id
+  subnet_ids                         = var.subnet_ids
+  transit_gateway_id                 = var.transit_gateway_id
+  vpc_id                             = var.vpc_id
+  security_group_referencing_support = var.security_group_referencing_support
 
   tags = {
     Name = var.name

--- a/aws/transit-gateway-attachment/variables.tf
+++ b/aws/transit-gateway-attachment/variables.tf
@@ -14,9 +14,3 @@ variable "name" {
   description = "The name tag of the tgw attachment"
   type        = string
 }
-
-variable "security_group_referencing_support" {
-  description = "Security Group Referencing allows to specify other SGs as references, or matching criterion in inbound security rules to allow instance-to-instance traffic"
-  type        = string
-  default     = "disable"
-}

--- a/aws/transit-gateway-attachment/variables.tf
+++ b/aws/transit-gateway-attachment/variables.tf
@@ -14,3 +14,9 @@ variable "name" {
   description = "The name tag of the tgw attachment"
   type        = string
 }
+
+variable "security_group_referencing_support" {
+  description = "Security Group Referencing allows to specify other SGs as references, or matching criterion in inbound security rules to allow instance-to-instance traffic"
+  type        = string
+  default     = "disable"
+}

--- a/aws/transit-gateway/README.md
+++ b/aws/transit-gateway/README.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.6.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.41.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.69.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.41.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.69.0 |
 
 ## Modules
 
@@ -33,6 +33,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_private_route_table_ids"></a> [private\_route\_table\_ids](#input\_private\_route\_table\_ids) | n/a | `list(string)` | n/a | yes |
 | <a name="input_public_route_table_ids"></a> [public\_route\_table\_ids](#input\_public\_route\_table\_ids) | n/a | `list(string)` | n/a | yes |
+| <a name="input_security_group_referencing_support"></a> [security\_group\_referencing\_support](#input\_security\_group\_referencing\_support) | Security Group Referencing allows to specify other SGs as references, or matching criterion in inbound security rules to allow instance-to-instance traffic | `string` | `"disable"` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | n/a | `list(string)` | n/a | yes |
 | <a name="input_transit_gateway_id"></a> [transit\_gateway\_id](#input\_transit\_gateway\_id) | n/a | `string` | n/a | yes |
 | <a name="input_transit_gtw_route_destination"></a> [transit\_gtw\_route\_destination](#input\_transit\_gtw\_route\_destination) | n/a | `string` | n/a | yes |

--- a/aws/transit-gateway/providers.tf
+++ b/aws/transit-gateway/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.41.0"
+      version = ">= 5.69.0"
     }
   }
 }

--- a/aws/transit-gateway/tgw_attachment.tf
+++ b/aws/transit-gateway/tgw_attachment.tf
@@ -1,7 +1,8 @@
 resource "aws_ec2_transit_gateway_vpc_attachment" "tgw_attachment" {
-  subnet_ids         = var.subnet_ids
-  transit_gateway_id = var.transit_gateway_id
-  vpc_id             = var.vpc_id
+  subnet_ids                         = var.subnet_ids
+  transit_gateway_id                 = var.transit_gateway_id
+  vpc_id                             = var.vpc_id
+  security_group_referencing_support = var.security_group_referencing_support
 }
 
 resource "aws_route" "private_tgw_attachment_route" {
@@ -51,4 +52,3 @@ resource "aws_route" "public_tgw_attachment_gitlab" {
   transit_gateway_id     = var.transit_gateway_id
   depends_on             = [aws_ec2_transit_gateway_vpc_attachment.tgw_attachment]
 }
-

--- a/aws/transit-gateway/variables.tf
+++ b/aws/transit-gateway/variables.tf
@@ -29,3 +29,9 @@ variable "transit_gtw_route_destination_security" {
 variable "transit_gtw_route_destination_gitlab" {
   type = string
 }
+
+variable "security_group_referencing_support" {
+  description = "Security Group Referencing allows to specify other SGs as references, or matching criterion in inbound security rules to allow instance-to-instance traffic"
+  type        = string
+  default     = "disable"
+}


### PR DESCRIPTION
#### Summary
add security_group_referencing_support in tgw and add support for macos for make setup

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8152

#### Release Note

```release-note
add security_group_referencing_support in tgw and add support for macos for make setup
```
