### PR TITLE
CLD-8459: Temporary change Ci image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,9 @@ on:
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+#    runs-on: ubuntu-latest Temporary comment out due to an issue with the latest version
+# https://github.com/actions/runner-images/issues/10796
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This is a temporary fix due to missing terraform command in ubuntu-latest in GitHub actions

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/CLD-8459

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
