### PR TITLE
add ability to enable versioning for s3 data bucket

### DIFF
--- a/aws/s3-data/README.md
+++ b/aws/s3-data/README.md
@@ -25,6 +25,7 @@ No modules.
 | [aws_s3_bucket.my_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_policy.my_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.block_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
+| [aws_s3_bucket_versioning.versioning_control](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
 | [aws_iam_policy_document.my_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -33,6 +34,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the bucket | `string` | n/a | yes |
 | <a name="input_iam_user_name"></a> [iam\_user\_name](#input\_iam\_user\_name) | The name of the IAM user to access the bucket | `string` | n/a | yes |
+| <a name="input_s3_bucket_enable_versioning"></a> [s3\_bucket\_enable\_versioning](#input\_s3\_bucket\_enable\_versioning) | If the s3 bucket versioning to be enabled | `string` | `true` | no |
 
 ## Outputs
 

--- a/aws/s3-data/main.tf
+++ b/aws/s3-data/main.tf
@@ -86,3 +86,11 @@ resource "aws_iam_user_policy_attachment" "attach_policy" {
   user       = aws_iam_user.my_user.name
   policy_arn = aws_iam_policy.my_user_policy.arn
 }
+
+# Enabling versioning control for my_bucket
+resource "aws_s3_bucket_versioning" "versioning_control" {
+  bucket = aws_s3_bucket.my_bucket.id
+  versioning_configuration {
+    status = var.s3_bucket_enable_versioning ? "Enabled" : "Disabled"
+  }
+}

--- a/aws/s3-data/variables.tf
+++ b/aws/s3-data/variables.tf
@@ -7,3 +7,9 @@ variable "iam_user_name" {
   type        = string
   description = "The name of the IAM user to access the bucket"
 }
+
+variable "s3_bucket_enable_versioning" {
+  type        = string
+  default     = true
+  description = "If the s3 bucket versioning to be enabled"
+}


### PR DESCRIPTION
#### Summary
add ability to enable versioning for s3 data bucket

#### Ticket Link


#### Release Note
https://mattermost.atlassian.net/browse/CLD-8563

```release-note
add ability to enable versioning for s3 data bucket
```
