### PR TITLE
add atlantis data eng user_id into S3 bucket policy

### DIFF
--- a/aws/s3-data/README.md
+++ b/aws/s3-data/README.md
@@ -26,6 +26,7 @@ No modules.
 | [aws_s3_bucket_policy.my_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_public_access_block.block_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [aws_s3_bucket_versioning.versioning_control](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.my_bucket_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs

--- a/aws/s3-data/main.tf
+++ b/aws/s3-data/main.tf
@@ -18,6 +18,8 @@ resource "aws_s3_bucket_policy" "my_bucket" {
   policy = data.aws_iam_policy_document.my_bucket_policy.json
 }
 
+data "aws_caller_identity" "current" {}
+
 # Define the IAM policy for the S3 bucket
 data "aws_iam_policy_document" "my_bucket_policy" {
   statement {
@@ -41,6 +43,7 @@ data "aws_iam_policy_document" "my_bucket_policy" {
 
       values = flatten([[
         aws_iam_user.my_user.unique_id,
+        data.aws_caller_identity.current.user_id,
         "AROA*"
       ]])
     }
@@ -80,6 +83,7 @@ EOF
 
 }
 
+data "aws_caller_identity" "current" {}
 
 # Attach the policy to the IAM user
 resource "aws_iam_user_policy_attachment" "attach_policy" {

--- a/aws/s3-data/main.tf
+++ b/aws/s3-data/main.tf
@@ -83,8 +83,6 @@ EOF
 
 }
 
-data "aws_caller_identity" "current" {}
-
 # Attach the policy to the IAM user
 resource "aws_iam_user_policy_attachment" "attach_policy" {
   user       = aws_iam_user.my_user.name


### PR DESCRIPTION
#### Summary
add atlantis data eng user_id into S3 bucket policy as Atlantis was failing to manage the bucket

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-8568

#### Release Note

```release-note
add atlantis data eng user_id into S3 bucket policy
```
