### PR TITLE
fix: Github Token passthrough on terraform

### DIFF
--- a/aws/eks-customer/remove-utility.tf
+++ b/aws/eks-customer/remove-utility.tf
@@ -5,6 +5,7 @@ resource "null_resource" "remove-utilities" {
     gitops_repo_url      = var.gitops_repo_url
     gitops_repo_username = var.gitops_repo_username
     gitops_repo_email    = var.gitops_repo_email
+    github_token         = data.github_app_token.this.token
     environment          = var.environment
     cluster_name         = module.eks.cluster_name
   }
@@ -18,7 +19,7 @@ resource "null_resource" "remove-utilities" {
       GIT_REPO_URL      = self.triggers.gitops_repo_url
       GIT_REPO_USERNAME = self.triggers.gitops_repo_username
       GIT_REPO_EMAIL    = self.triggers.gitops_repo_email
-      GITHUB_TOKEN      = data.github_app_token.this.token
+      GITHUB_TOKEN      = self.triggers.github_token
       CLUSTER_NAME      = self.triggers.cluster_name
       ENV               = self.triggers.environment
     }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
Resolving this issue: 
```
Error: Invalid reference from destroy provisioner

  on .terraform/modules/eks/aws/eks-customer/remove-utility.tf line 16, in resource "null_resource" "remove-utilities":
  16:     environment = {
  17:       GIT_REPO_PATH     = self.triggers.gitops_repo_path
  18:       GIT_REPO_URL      = self.triggers.gitops_repo_url
  19:       GIT_REPO_USERNAME = self.triggers.gitops_repo_username
  20:       GIT_REPO_EMAIL    = self.triggers.gitops_repo_email
  21:       GITHUB_TOKEN      = data.github_app_token.this.token
  22:       CLUSTER_NAME      = self.triggers.cluster_name
  23:       ENV               = self.triggers.environment
  24:     }

Destroy-time provisioners and their connection configurations may only
reference attributes of the related resource, via 'self', 'count.index', or
'each.key'.

References to other resources during the destroy phase can cause dependency
cycles and interact poorly with create_before_destroy.

```
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
