### PR TITLE
CLD-8964: Make PR instead of commit utilities to main

### DIFF
--- a/aws/eks-customer/README.md
+++ b/aws/eks-customer/README.md
@@ -103,7 +103,7 @@
 | <a name="input_github_app_installation_id"></a> [github\_app\_installation\_id](#input\_github\_app\_installation\_id) | The installation id for the Github App | `string` | n/a | yes |
 | <a name="input_github_app_pem_key_path"></a> [github\_app\_pem\_key\_path](#input\_github\_app\_pem\_key\_path) | The path of the Github App PEM | `string` | n/a | yes |
 | <a name="input_gitops_repo_email"></a> [gitops\_repo\_email](#input\_gitops\_repo\_email) | The git repo email for executing git commands | `string` | n/a | yes |
-| <a name="input_gitops_repo_path"></a> [gitops\_repo\_path](#input\_gitops\_repo\_path) | The git repo url | `string` | n/a | yes |
+| <a name="input_gitops_repo_path"></a> [gitops\_repo\_path](#input\_gitops\_repo\_path) | The git repo path | `string` | n/a | yes |
 | <a name="input_gitops_repo_url"></a> [gitops\_repo\_url](#input\_gitops\_repo\_url) | The git repo url | `string` | n/a | yes |
 | <a name="input_gitops_repo_username"></a> [gitops\_repo\_username](#input\_gitops\_repo\_username) | The git repo username for executing git commands | `string` | n/a | yes |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `false` | no |
@@ -114,6 +114,7 @@
 | <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | The list of node groups | `any` | `{}` | no |
 | <a name="input_private_domain"></a> [private\_domain](#input\_private\_domain) | The private domain | `string` | n/a | yes |
 | <a name="input_provisioner_role_arn"></a> [provisioner\_role\_arn](#input\_provisioner\_role\_arn) | The provisioner role arn | `string` | n/a | yes |
+| <a name="input_push_utilities_to_main"></a> [push\_utilities\_to\_main](#input\_push\_utilities\_to\_main) | Indicates whether or not to automatically push utilities to the Gitops repository | `bool` | `true` | no |
 | <a name="input_region"></a> [region](#input\_region) | The region for the EKS cluster | `string` | `"us-east-1"` | no |
 | <a name="input_snapshot_controller_version"></a> [snapshot\_controller\_version](#input\_snapshot\_controller\_version) | n/a | `string` | n/a | yes |
 | <a name="input_staff_role_arn"></a> [staff\_role\_arn](#input\_staff\_role\_arn) | The staff role arn | `string` | n/a | yes |

--- a/aws/eks-customer/scripts/deploy-utility.sh
+++ b/aws/eks-customer/scripts/deploy-utility.sh
@@ -56,8 +56,13 @@ function deploy_utility() {
 
 	done
 
-  push_changes_to_git
-  
+  # PUSH_UTILITIES_TO_MAIN if this value is set to true, then push the changes to main
+  if [[ $PUSH_UTILITIES_TO_MAIN == "false" ]]; then
+    push_changes_to_git $BRANCH_NAME
+    make_pr $BRANCH_NAME
+  else
+    push_changes_to_git "main"
+  fi
 }
 
 function add_utility_to_application_file() {
@@ -132,6 +137,9 @@ function wait_for_healthy() {
 
 function main() {
   clone_repo
+  if [[ $PUSH_UTILITIES_TO_MAIN == "false" ]]; then
+    create_new_branch $BRANCH_NAME
+  fi
   add_cluster
   create_cluster_folder
   deploy_utility

--- a/aws/eks-customer/utility.tf
+++ b/aws/eks-customer/utility.tf
@@ -23,6 +23,8 @@ resource "null_resource" "deploy-utilites" {
       ARGOCD_ROLE_ARN            = var.argocd_role_arn
       ARGOCD_SERVER              = var.argocd_server
       AWS_ACCOUNT                = data.aws_caller_identity.current.account_id
+      PUSH_UTILITIES_TO_MAIN     = var.push_utilities_to_main
+      BRANCH_NAME                = "${module.eks.cluster_name}-deploy-utilities-${formatdate("YYMMDDhhss", timestamp())}--delete-after-merge"
     }
   }
 

--- a/aws/eks-customer/variables.tf
+++ b/aws/eks-customer/variables.tf
@@ -127,7 +127,7 @@ variable "gitops_repo_url" {
 }
 
 variable "gitops_repo_path" {
-  description = "The git repo url"
+  description = "The git repo path"
   type        = string
 }
 
@@ -308,4 +308,10 @@ variable "update_config" {
   default = {
     max_unavailable = 1
   }
+}
+
+variable "push_utilities_to_main" {
+  description = "Indicates whether or not to automatically push utilities to the Gitops repository"
+  type        = bool
+  default     = true
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Optionally we can make PR instead of commit utilities directly to main. This is a safeguard especially for production environment.

#### Ticket Link
Fix https://mattermost.atlassian.net/browse/CLD-8964

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
eks-customer add option to make a PR for utilities deploy
```
