### PR TITLE
migrate tag-based references to commit SHA-based references for github workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,12 +8,12 @@ on:
 jobs:
   lint:
     name: Lint
-#    runs-on: ubuntu-latest Temporary comment out due to an issue with the latest version
-# https://github.com/actions/runner-images/issues/10796
+    #    runs-on: ubuntu-latest Temporary comment out due to an issue with the latest version
+    # https://github.com/actions/runner-images/issues/10796
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Setup
         run: make setup


### PR DESCRIPTION
#### Summary
Migrate tag-based references to commit SHA-based references for github workflows

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9005

