### PR TITLE
CLD-9026: add initial setup for pgbouncer

### DIFF
--- a/aws/eks-customer/README.md
+++ b/aws/eks-customer/README.md
@@ -54,6 +54,7 @@
 | [null_resource.delete_aws_node](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.deploy-utilites](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.install_calico_operator](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [null_resource.pgbouncer_initial_setup](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.tag_vpc](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.wait_for_nginx_internal_lb](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
 | [null_resource.wait_for_thanos_query_grpc_lb](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |

--- a/aws/eks-customer/scripts/pgbouncer-initial-setup.yaml
+++ b/aws/eks-customer/scripts/pgbouncer-initial-setup.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    kubernetes.io/metadata.name: pgbouncer
+    name: pgbouncer
+  name: pgbouncer
+---
+apiVersion: v1
+data:
+  pgbouncer.ini: |2
+
+    [pgbouncer]
+    listen_addr = *
+    listen_port = 5432
+    auth_type = any
+    admin_users = admin
+    ignore_startup_parameters = extra_float_digits
+    tcp_keepalive = 1
+    tcp_keepcnt = 5
+    tcp_keepidle = 5
+    tcp_keepintvl = 1
+    server_round_robin = 1
+    log_disconnections = 1
+    log_connections = 1
+    pool_mode = transaction
+    min_pool_size = 1
+    default_pool_size = 5
+    reserve_pool_size = 10
+    reserve_pool_timeout = 1
+    max_client_conn = 20000
+    max_db_connections = 20
+    server_idle_timeout = 30
+    server_lifetime = 300
+    server_reset_query_always = 0
+
+    [databases]
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/instance: pgbouncer
+    app.kubernetes.io/managed-by: provisioner
+    app.kubernetes.io/name: pgbouncer
+  name: pgbouncer-configmap
+  namespace: pgbouncer
+---
+apiVersion: v1
+data:
+  userlist.txt: Zm9vCg== # foo
+kind: Secret
+metadata:
+  labels:
+    app.kubernetes.io/instance: pgbouncer
+    app.kubernetes.io/managed-by: provisioner
+    app.kubernetes.io/name: pgbouncer
+  name: pgbouncer-userlist-secret
+  namespace: pgbouncer
+type: Opaque

--- a/aws/eks-customer/utility-utils.tf
+++ b/aws/eks-customer/utility-utils.tf
@@ -66,3 +66,12 @@ resource "null_resource" "wait_for_nginx_internal_lb" {
 
   depends_on = [null_resource.deploy-utilites]
 }
+
+resource "null_resource" "pgbouncer_initial_setup" {
+  provisioner "local-exec" {
+    command = <<EOF
+      KUBECONFIG=${path.root}/kubeconfig-${module.eks.cluster_name} kubectl apply -f ${path.module}/scripts/pgbouncer-initial-setup.yaml
+EOF
+  }
+  depends_on = [module.managed_node_group.node_group_status]
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
This change will add an initial setup for pgBouncer. It will run once during cluster creation, removing pgBouncer configs from Argocd. After cluster creation, the provisioner will handle the pgBouncer configurations.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9026

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Add initial setup for pgbouncer in eks-customer module
```
