### PR TITLE
Add roles for lambda upload to substitute legacy user resources

### DIFF
--- a/aws/cloud-lambda-storage/README.md
+++ b/aws/cloud-lambda-storage/README.md
@@ -20,6 +20,8 @@ No modules.
 | Name | Type |
 |------|------|
 | [aws_iam_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.lambda_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.attach_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_user.lambda_user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_policy_attachment.attach_s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy_attachment) | resource |
 | [aws_s3_bucket.lambdas_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |

--- a/aws/cloud-lambda-storage/iam.tf
+++ b/aws/cloud-lambda-storage/iam.tf
@@ -3,6 +3,26 @@ resource "aws_iam_user" "lambda_user" {
   path = "/"
 }
 
+resource "aws_iam_role" "lambda_role" {
+  name = "mattermost-cloud-lambdas-upload-${var.environment}-lambda-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          "Service" : "s3.amazonaws.com"
+        }
+        Action = [
+          "sts:TagSession",
+          "sts:AssumeRole"
+        ]
+      }
+    ]
+  })
+}
+
 resource "aws_iam_policy" "s3" {
   name        = "mattermost-cloud-lambdas-upload-${var.environment}"
   path        = "/"
@@ -46,4 +66,10 @@ EOF
 resource "aws_iam_user_policy_attachment" "attach_s3" {
   user       = aws_iam_user.lambda_user.name
   policy_arn = aws_iam_policy.s3.arn
+}
+
+
+resource "aws_iam_role_policy_attachment" "attach_s3" {
+  policy_arn = aws_iam_policy.s3.arn
+  role       = aws_iam_role.lambda_role.name
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Add roles for lambda upload to substitute legacy user resources

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9143

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
