### PR TITLE
[CLD-9174] handle launch template outside the managed node group module

### DIFF
--- a/aws/eks-customer/README.md
+++ b/aws/eks-customer/README.md
@@ -44,6 +44,7 @@
 | [aws_iam_policy.external-secrets](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.velero](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_launch_template.node](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
 | [aws_route53_record.internal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_secretsmanager_secret.kubeconfig_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_version.kubeconfig_secret_version](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
@@ -64,6 +65,7 @@
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_lb.internal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
 | [aws_lb.thanos-query-grpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_route53_zone.internal](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
 | [aws_security_groups.calls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_groups) | data source |
 | [aws_security_groups.control-plane](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_groups) | data source |
@@ -94,9 +96,11 @@
 | <a name="input_create_cluster_security_group"></a> [create\_cluster\_security\_group](#input\_create\_cluster\_security\_group) | Indicates whether or not to create a security group for the EKS cluster | `bool` | `true` | no |
 | <a name="input_create_iam_role"></a> [create\_iam\_role](#input\_create\_iam\_role) | Determines whether an IAM role is created or to use an existing IAM role | `bool` | `true` | no |
 | <a name="input_create_kms_key"></a> [create\_kms\_key](#input\_create\_kms\_key) | Controls if a KMS key for cluster encryption should be created | `bool` | `false` | no |
+| <a name="input_create_launch_template"></a> [create\_launch\_template](#input\_create\_launch\_template) | Indicates whether or not to create a launch template for the EKS managed node group | `bool` | `false` | no |
 | <a name="input_create_node_security_group"></a> [create\_node\_security\_group](#input\_create\_node\_security\_group) | Indicates whether or not to create a security group for the EKS nodes | `bool` | `false` | no |
 | <a name="input_device_name"></a> [device\_name](#input\_device\_name) | The device name | `string` | `"/dev/xvda"` | no |
 | <a name="input_ebs_csi_driver_version"></a> [ebs\_csi\_driver\_version](#input\_ebs\_csi\_driver\_version) | The version of the EBS CSI driver addon | `string` | n/a | yes |
+| <a name="input_ebs_optimized"></a> [ebs\_optimized](#input\_ebs\_optimized) | If true, the launched EC2 instance will be EBS-optimized | `bool` | `null` | no |
 | <a name="input_efs_csi_driver_version"></a> [efs\_csi\_driver\_version](#input\_efs\_csi\_driver\_version) | The version of the EFS CSI driver addon | `string` | n/a | yes |
 | <a name="input_eks_cluster_admin_policy_arn"></a> [eks\_cluster\_admin\_policy\_arn](#input\_eks\_cluster\_admin\_policy\_arn) | The ARN of the AmazonEKSClusterAdminPolicy | `string` | `"arn:aws:eks::aws:cluster-access-policy/AmazonEKSClusterAdminPolicy"` | no |
 | <a name="input_enable_auto_mode_custom_tags"></a> [enable\_auto\_mode\_custom\_tags](#input\_enable\_auto\_mode\_custom\_tags) | Indicates whether or not to enable auto mode custom tags | `bool` | `false` | no |
@@ -110,7 +114,6 @@
 | <a name="input_gitops_repo_username"></a> [gitops\_repo\_username](#input\_gitops\_repo\_username) | The git repo username for executing git commands | `string` | n/a | yes |
 | <a name="input_iam_role_use_name_prefix"></a> [iam\_role\_use\_name\_prefix](#input\_iam\_role\_use\_name\_prefix) | Determines whether the IAM role name (`iam_role_name`) is used as a prefix | `bool` | `false` | no |
 | <a name="input_kube_proxy_version"></a> [kube\_proxy\_version](#input\_kube\_proxy\_version) | The version of the kube-proxy addon | `string` | n/a | yes |
-| <a name="input_launch_template_use_name_prefix"></a> [launch\_template\_use\_name\_prefix](#input\_launch\_template\_use\_name\_prefix) | Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix | `bool` | `true` | no |
 | <a name="input_lb_certificate_arn"></a> [lb\_certificate\_arn](#input\_lb\_certificate\_arn) | The certificate arn | `string` | n/a | yes |
 | <a name="input_lb_private_certificate_arn"></a> [lb\_private\_certificate\_arn](#input\_lb\_private\_certificate\_arn) | The private certificate arn | `string` | n/a | yes |
 | <a name="input_node_groups"></a> [node\_groups](#input\_node\_groups) | The list of node groups | `any` | `{}` | no |
@@ -121,6 +124,7 @@
 | <a name="input_snapshot_controller_version"></a> [snapshot\_controller\_version](#input\_snapshot\_controller\_version) | n/a | `string` | n/a | yes |
 | <a name="input_staff_role_arn"></a> [staff\_role\_arn](#input\_staff\_role\_arn) | The staff role arn | `string` | n/a | yes |
 | <a name="input_update_config"></a> [update\_config](#input\_update\_config) | Configuration block of settings for max unavailable resources during node group updates | `map(string)` | <pre>{<br/>  "max_unavailable": 1<br/>}</pre> | no |
+| <a name="input_use_al2023"></a> [use\_al2023](#input\_use\_al2023) | Enable AL2023-specific configurations. Defaults to false for AL2. | `bool` | `false` | no |
 | <a name="input_use_name_prefix"></a> [use\_name\_prefix](#input\_use\_name\_prefix) | Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix | `bool` | `true` | no |
 | <a name="input_utilities"></a> [utilities](#input\_utilities) | The list of utilities | <pre>list(object({<br/>    name                      = string<br/>    enable_irsa               = bool<br/>    internal_dns              = any<br/>    namespace_service_account = string<br/>    cluster_label_type        = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_volume_delete_on_termination"></a> [volume\_delete\_on\_termination](#input\_volume\_delete\_on\_termination) | Indicates whether the EBS volume is deleted on termination | `bool` | `true` | no |
@@ -128,6 +132,7 @@
 | <a name="input_volume_iops"></a> [volume\_iops](#input\_volume\_iops) | The amount of provisioned IOPS | `number` | `3000` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | The size of the EBS volume | `number` | `128` | no |
 | <a name="input_volume_throughput"></a> [volume\_throughput](#input\_volume\_throughput) | The throughput of the EBS volume | `number` | `125` | no |
+| <a name="input_volume_type"></a> [volume\_type](#input\_volume\_type) | Worker node volume type | `string` | `"gp3"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the EKS cluster | `string` | n/a | yes |
 | <a name="input_wait_for_cluster_timeout"></a> [wait\_for\_cluster\_timeout](#input\_wait\_for\_cluster\_timeout) | The timeout to wait for the EKS cluster to be ready | `string` | `"5m"` | no |
 

--- a/aws/eks-customer/data.tf
+++ b/aws/eks-customer/data.tf
@@ -2,6 +2,8 @@ data "aws_caller_identity" "current" {}
 
 data "aws_availability_zones" "available" {}
 
+data "aws_region" "current" {}
+
 data "aws_route53_zone" "internal" {
   name         = "internal.${var.environment}.${var.private_domain}"
   private_zone = true

--- a/aws/eks-customer/eks_managed_node-group.tf
+++ b/aws/eks-customer/eks_managed_node-group.tf
@@ -5,41 +5,23 @@ module "managed_node_group" {
   for_each = { for k, v in var.node_groups : k => v }
 
 
-  name                            = "${each.key}-${module.eks.cluster_name}"
-  cluster_name                    = module.eks.cluster_name
-  cluster_version                 = module.eks.cluster_version
-  use_name_prefix                 = var.use_name_prefix
-  launch_template_use_name_prefix = var.launch_template_use_name_prefix
-  iam_role_use_name_prefix        = var.iam_role_use_name_prefix
-
-  network_interfaces = each.value.network_interfaces
-
-  block_device_mappings = {
-    xvda = {
-      device_name = var.device_name
-      ebs = {
-        volume_size           = var.volume_size
-        volume_type           = "gp3"
-        iops                  = var.volume_iops
-        throughput            = var.volume_throughput
-        encrypted             = var.volume_encrypted
-        delete_on_termination = var.volume_delete_on_termination
-      }
-    }
-  }
-
-  enable_bootstrap_user_data = true
-  ami_id                     = each.value.ami_id
-  instance_types             = each.value.instance_types
+  name                     = "${each.key}-${module.eks.cluster_name}"
+  cluster_name             = module.eks.cluster_name
+  cluster_version          = module.eks.cluster_version
+  use_name_prefix          = var.use_name_prefix
+  iam_role_use_name_prefix = var.iam_role_use_name_prefix
+  create_launch_template   = var.create_launch_template
+  launch_template_id       = aws_launch_template.node[each.key].id
+  launch_template_name     = aws_launch_template.node[each.key].name
+  launch_template_version  = aws_launch_template.node[each.key].latest_version
+  ami_id                   = each.value.ami_id
 
   iam_role_additional_policies = {
     cloudNode = aws_iam_policy.node.arn
   }
 
-  cluster_service_cidr              = module.eks.cluster_service_cidr
-  cluster_primary_security_group_id = module.eks.cluster_primary_security_group_id
-  vpc_security_group_ids            = strcontains(each.key, "calls") ? data.aws_security_groups.calls.ids : data.aws_security_groups.nodes.ids
-  subnet_ids                        = (each.value.public_subnet == false) ? (strcontains(each.key, "monitoring") ? data.aws_subnets.private-a.ids : data.aws_subnets.private.ids) : data.aws_subnets.public.ids
+  cluster_service_cidr = module.eks.cluster_service_cidr
+  subnet_ids           = (each.value.public_subnet == false) ? (strcontains(each.key, "monitoring") ? data.aws_subnets.private-a.ids : data.aws_subnets.private.ids) : data.aws_subnets.public.ids
 
   min_size     = each.value.min_size
   max_size     = each.value.max_size

--- a/aws/eks-customer/launch_template.tf
+++ b/aws/eks-customer/launch_template.tf
@@ -1,0 +1,95 @@
+resource "aws_launch_template" "node" {
+  for_each = { for k, v in var.node_groups : k => v }
+
+
+  name        = "${each.key}-${module.eks.cluster_name}"
+  description = "${each.key}-${module.eks.cluster_name} cluster nodes launch template"
+
+  # This is to avoid conflicts with the EKS managed node group: InvalidRequestException: Network interfaces and an instance-level security groups may not be specified on the same request
+  vpc_security_group_ids = length(each.value.network_interfaces) > 0 ? [] : compact(concat([module.eks.cluster_primary_security_group_id], strcontains(each.key, "calls") ? data.aws_security_groups.calls.ids : data.aws_security_groups.nodes.ids))
+
+  block_device_mappings {
+    device_name = var.device_name
+    ebs {
+      volume_size           = var.volume_size
+      volume_type           = var.volume_type
+      iops                  = var.volume_iops
+      throughput            = var.volume_throughput
+      encrypted             = var.volume_encrypted
+      delete_on_termination = var.volume_delete_on_termination
+    }
+  }
+
+  dynamic "network_interfaces" {
+    for_each = each.value.network_interfaces
+
+    content {
+      associate_carrier_ip_address = try(network_interfaces.value.associate_carrier_ip_address, null)
+      associate_public_ip_address  = try(network_interfaces.value.associate_public_ip_address, null)
+      delete_on_termination        = try(network_interfaces.value.delete_on_termination, null)
+      description                  = try(network_interfaces.value.description, null)
+      device_index                 = try(network_interfaces.value.device_index, null)
+      interface_type               = try(network_interfaces.value.interface_type, null)
+      ipv4_address_count           = try(network_interfaces.value.ipv4_address_count, null)
+      ipv4_addresses               = try(network_interfaces.value.ipv4_addresses, [])
+      ipv4_prefix_count            = try(network_interfaces.value.ipv4_prefix_count, null)
+      ipv4_prefixes                = try(network_interfaces.value.ipv4_prefixes, null)
+      ipv6_address_count           = try(network_interfaces.value.ipv6_address_count, null)
+      ipv6_addresses               = try(network_interfaces.value.ipv6_addresses, [])
+      ipv6_prefix_count            = try(network_interfaces.value.ipv6_prefix_count, null)
+      ipv6_prefixes                = try(network_interfaces.value.ipv6_prefixes, [])
+      network_card_index           = try(network_interfaces.value.network_card_index, null)
+      network_interface_id         = try(network_interfaces.value.network_interface_id, null)
+      primary_ipv6                 = try(network_interfaces.value.primary_ipv6, null)
+      private_ip_address           = try(network_interfaces.value.private_ip_address, null)
+      # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/4570
+      security_groups = compact(concat(try(network_interfaces.value.security_groups, []), compact(concat([module.eks.cluster_primary_security_group_id], strcontains(each.key, "calls") ? data.aws_security_groups.calls.ids : data.aws_security_groups.nodes.ids))))
+      # Set on EKS managed node group, will fail if set here
+      # https://docs.aws.amazon.com/eks/latest/userguide/launch-templates.html#launch-template-basics
+      # subnet_id       = try(network_interfaces.value.subnet_id, null)
+    }
+  }
+
+  image_id      = var.use_al2023 ? each.value.al2023_ami_id : each.value.ami_id
+  instance_type = element(each.value.instance_types, 0)
+  ebs_optimized = var.ebs_optimized
+
+  user_data = var.use_al2023 ? base64encode(<<USERDATA
+#!/bin/bash
+echo "export AWS_REGION=${data.aws_region.current.name}" >> /etc/environment
+source /etc/environment
+cat <<EOF > /etc/eks/nodeadm-config.yaml
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: ${module.eks.cluster_name}
+    apiServerEndpoint: |
+      ${module.eks.cluster_endpoint}
+    certificateAuthority: |
+      ${module.eks.cluster_certificate_authority_data}
+    cidr: ${module.eks.cluster_service_cidr}
+EOF
+
+/usr/local/bin/nodeadm init -c file:///etc/eks/nodeadm-config.yaml
+USERDATA
+    ) : base64encode(<<USERDATA
+#!/bin/bash
+set -e
+B64_CLUSTER_CA=${module.eks.cluster_certificate_authority_data}
+API_SERVER_URL=${module.eks.cluster_endpoint}
+/etc/eks/bootstrap.sh ${module.eks.cluster_name}  --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL \
+  --ip-family ipv4 --service-ipv4-cidr ${module.eks.cluster_service_cidr}
+USERDATA
+  )
+
+  tag_specifications {
+    resource_type = "instance"
+
+    tags = {
+      Name              = "${each.key}-${module.eks.cluster_name}"
+      KubernetesCluster = module.eks.cluster_name
+      VpcID             = var.vpc_id
+    }
+  }
+}

--- a/aws/eks-customer/variables.tf
+++ b/aws/eks-customer/variables.tf
@@ -254,12 +254,6 @@ variable "use_name_prefix" {
   default     = true
 }
 
-# variable "launch_template_use_name_prefix" {
-#   description = "Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix"
-#   type        = bool
-#   default     = true
-# }
-
 variable "iam_role_use_name_prefix" {
   description = "Determines whether the IAM role name (`iam_role_name`) is used as a prefix"
   type        = bool

--- a/aws/eks-customer/variables.tf
+++ b/aws/eks-customer/variables.tf
@@ -251,7 +251,7 @@ variable "wait_for_cluster_timeout" {
 variable "use_name_prefix" {
   description = "Determines whether to use `name` as is or create a unique name beginning with the `name` as the prefix"
   type        = bool
-  default     = true
+  default     = false
 }
 
 variable "iam_role_use_name_prefix" {

--- a/aws/eks-customer/variables.tf
+++ b/aws/eks-customer/variables.tf
@@ -254,11 +254,11 @@ variable "use_name_prefix" {
   default     = true
 }
 
-variable "launch_template_use_name_prefix" {
-  description = "Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix"
-  type        = bool
-  default     = true
-}
+# variable "launch_template_use_name_prefix" {
+#   description = "Determines whether to use `launch_template_name` as is or create a unique name beginning with the `launch_template_name` as the prefix"
+#   type        = bool
+#   default     = true
+# }
 
 variable "iam_role_use_name_prefix" {
   description = "Determines whether the IAM role name (`iam_role_name`) is used as a prefix"
@@ -270,6 +270,12 @@ variable "volume_size" {
   description = "The size of the EBS volume"
   type        = number
   default     = 128
+}
+
+variable "volume_type" {
+  default     = "gp3"
+  type        = string
+  description = "Worker node volume type"
 }
 
 variable "device_name" {
@@ -314,4 +320,22 @@ variable "push_utilities_to_main" {
   description = "Indicates whether or not to automatically push utilities to the Gitops repository"
   type        = bool
   default     = true
+}
+
+variable "create_launch_template" {
+  description = "Indicates whether or not to create a launch template for the EKS managed node group"
+  type        = bool
+  default     = false
+}
+
+variable "use_al2023" {
+  description = "Enable AL2023-specific configurations. Defaults to false for AL2."
+  type        = bool
+  default     = false
+}
+
+variable "ebs_optimized" {
+  description = "If true, the launched EC2 instance will be EBS-optimized"
+  default     = null
+  type        = bool
 }


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
In this PR we'll handle the launch template outside the `eks-managed-node-group` module passing the launch template values to it. This guarantees a smooth rollout process, triggering EKS node group updates when changes are applied.

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9174

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
[eks-customer]: Handle launch templates outside eks-managed-node-group module
```
