### PR TITLE
change plugin store role to be assumed by public repos

### DIFF
--- a/aws/iam-custom-resources-release/local.tf
+++ b/aws/iam-custom-resources-release/local.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_region" "current" {}

--- a/aws/iam-custom-resources-release/plugin-store.tf
+++ b/aws/iam-custom-resources-release/plugin-store.tf
@@ -7,12 +7,19 @@ resource "aws_iam_role" "plugin_store_role" {
       {
         Effect = "Allow"
         Principal = {
-          AWS = var.github_runners_iam_role_arn
+          Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
         }
         Action = [
-          "sts:TagSession",
-          "sts:AssumeRole"
+          "sts:AssumeRoleWithWebIdentity"
         ]
+        Condition = {
+          StringLike = {
+            "token.actions.githubusercontent.com:sub" : var.github_repos_sub
+          }
+          StringEquals = {
+            "token.actions.githubusercontent.com:aud" : "sts.amazonaws.com"
+          }
+        }
       }
     ]
   })

--- a/aws/iam-custom-resources-release/variables.tf
+++ b/aws/iam-custom-resources-release/variables.tf
@@ -8,3 +8,8 @@ variable "github_runners_iam_role_arn" {
   description = "Github runner role ARN"
   type        = string
 }
+
+variable "github_repos_sub" {
+  description = "Github repos sub"
+  type        = list(string)
+}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
change plugin store role to be assumed by public repos
#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->
https://mattermost.atlassian.net/browse/CLD-9264
```release-note
change plugin store role to be assumed by public repos
```
