### PR TITLE
Ability to set disk parameters per node group

### DIFF
--- a/aws/eks-customer/README.md
+++ b/aws/eks-customer/README.md
@@ -123,9 +123,7 @@
 | <a name="input_utilities"></a> [utilities](#input\_utilities) | The list of utilities | <pre>list(object({<br/>    name                      = string<br/>    enable_irsa               = bool<br/>    internal_dns              = any<br/>    namespace_service_account = string<br/>    cluster_label_type        = string<br/>  }))</pre> | n/a | yes |
 | <a name="input_volume_delete_on_termination"></a> [volume\_delete\_on\_termination](#input\_volume\_delete\_on\_termination) | Indicates whether the EBS volume is deleted on termination | `bool` | `true` | no |
 | <a name="input_volume_encrypted"></a> [volume\_encrypted](#input\_volume\_encrypted) | Indicates whether the EBS volume is encrypted | `bool` | `true` | no |
-| <a name="input_volume_iops"></a> [volume\_iops](#input\_volume\_iops) | The amount of provisioned IOPS | `number` | `3000` | no |
 | <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | The size of the EBS volume | `number` | `128` | no |
-| <a name="input_volume_throughput"></a> [volume\_throughput](#input\_volume\_throughput) | The throughput of the EBS volume | `number` | `125` | no |
 | <a name="input_volume_type"></a> [volume\_type](#input\_volume\_type) | Worker node volume type | `string` | `"gp3"` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the EKS cluster | `string` | n/a | yes |
 | <a name="input_wait_for_cluster_timeout"></a> [wait\_for\_cluster\_timeout](#input\_wait\_for\_cluster\_timeout) | The timeout to wait for the EKS cluster to be ready | `string` | `"5m"` | no |

--- a/aws/eks-customer/launch_template.tf
+++ b/aws/eks-customer/launch_template.tf
@@ -13,8 +13,8 @@ resource "aws_launch_template" "node" {
     ebs {
       volume_size           = var.volume_size
       volume_type           = var.volume_type
-      iops                  = var.volume_iops
-      throughput            = var.volume_throughput
+      iops                  = lookup(each.value, "volume_iops", 3000)
+      throughput            = lookup(each.value, "volume_throughput", 125)
       encrypted             = var.volume_encrypted
       delete_on_termination = var.volume_delete_on_termination
     }

--- a/aws/eks-customer/variables.tf
+++ b/aws/eks-customer/variables.tf
@@ -278,17 +278,17 @@ variable "device_name" {
   default     = "/dev/xvda"
 }
 
-variable "volume_iops" {
-  description = "The amount of provisioned IOPS"
-  type        = number
-  default     = 3000
-}
+# variable "volume_iops" {
+#   description = "The amount of provisioned IOPS"
+#   type        = number
+#   default     = 3000
+# }
 
-variable "volume_throughput" {
-  description = "The throughput of the EBS volume"
-  type        = number
-  default     = 125
-}
+# variable "volume_throughput" {
+#   description = "The throughput of the EBS volume"
+#   type        = number
+#   default     = 125
+# }
 
 variable "volume_encrypted" {
   description = "Indicates whether the EBS volume is encrypted"

--- a/aws/eks-customer/variables.tf
+++ b/aws/eks-customer/variables.tf
@@ -278,18 +278,6 @@ variable "device_name" {
   default     = "/dev/xvda"
 }
 
-# variable "volume_iops" {
-#   description = "The amount of provisioned IOPS"
-#   type        = number
-#   default     = 3000
-# }
-
-# variable "volume_throughput" {
-#   description = "The throughput of the EBS volume"
-#   type        = number
-#   default     = 125
-# }
-
 variable "volume_encrypted" {
   description = "Indicates whether the EBS volume is encrypted"
   type        = bool


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Ability to set disk Iops and throughput per node group

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9287

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
eks-customer Ability to set disk IOPS and throughput per node group
```
