### PR TITLE
remove uneeded dependency

### DIFF
--- a/aws/eks-customer/eks_managed_node-group.tf
+++ b/aws/eks-customer/eks_managed_node-group.tf
@@ -36,8 +36,6 @@ module "managed_node_group" {
     Environment = var.environment
     Terraform   = "true"
   }
-
-  depends_on = [module.eks, time_sleep.wait_for_cluster]
 }
 
 resource "null_resource" "node_group_annotate" {


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Depending on the change we make, we often trigger IAM role policy replace for node groups, and Terraform ends up removing the policy. To fix it we need to remove the `depends_on` from the module. This will not affect the order of things because we have references from the cluster module in the node group.

Some references: https://github.com/hashicorp/terraform/issues/30340#issuecomment-1010202582
https://github.com/terraform-aws-modules/terraform-aws-eks/issues/3297

#### Ticket Link
https://mattermost.atlassian.net/browse/CLD-9465

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
