### PR TITLE
Fix userdata to add pause container image

### DIFF
--- a/aws/cluster/README.md
+++ b/aws/cluster/README.md
@@ -23,7 +23,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_managed_node_group"></a> [managed\_node\_group](#module\_managed\_node\_group) | github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups | v1.8.49 |
+| <a name="module_managed_node_group"></a> [managed\_node\_group](#module\_managed\_node\_group) | github.com/mattermost/mattermost-cloud-monitoring.git//aws/eks-managed-node-groups | v1.8.96 |
 
 ## Resources
 

--- a/aws/cluster/locals.tf
+++ b/aws/cluster/locals.tf
@@ -25,6 +25,12 @@ CONFIGMAPAWSAUTH
 #!/bin/bash
 set -e
 
+# Fix sandbox image before nodeadm runs
+sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
+
+# Restart containerd to apply config
+systemctl restart containerd
+
 echo Configuring nodeadm for AL2023
 cat <<EOF > /etc/eks/nodeadm-config.yaml
 apiVersion: node.eks.aws/v1alpha1
@@ -35,10 +41,6 @@ spec:
     apiServerEndpoint: ${aws_eks_cluster.cluster.endpoint}
     certificateAuthority: ${aws_eks_cluster.cluster.certificate_authority[0].data}
     cidr: ${local.service_cidr}
-  containerd:
-    config: |
-      [plugins."io.containerd.grpc.v1.cri"]
-        sandbox_image = "${var.pause_container_image}"
 EOF
 
 /usr/local/bin/nodeadm --config /etc/eks/nodeadm-config.yaml

--- a/aws/eks-customer/launch_template.tf
+++ b/aws/eks-customer/launch_template.tf
@@ -58,6 +58,13 @@ resource "aws_launch_template" "node" {
 #!/bin/bash
 echo "export AWS_REGION=${data.aws_region.current.name}" >> /etc/environment
 source /etc/environment
+
+# Fix sandbox image before nodeadm runs
+sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
+
+# Restart containerd to apply config
+systemctl restart containerd
+
 cat <<EOF > /etc/eks/nodeadm-config.yaml
 apiVersion: node.eks.aws/v1alpha1
 kind: NodeConfig
@@ -72,10 +79,6 @@ spec:
   kubelet:
     config:
       maxPods: ${lookup(each.value, "max_pods", 110)}
-  containerd:
-    config: |
-      [plugins."io.containerd.grpc.v1.cri"]
-        sandbox_image = "${var.pause_container_image}"
 EOF
 
 /usr/local/bin/nodeadm init -c file:///etc/eks/nodeadm-config.yaml

--- a/aws/eks-managed-node-groups/node_groups.tf
+++ b/aws/eks-managed-node-groups/node_groups.tf
@@ -22,6 +22,13 @@ resource "aws_launch_template" "cluster_nodes_eks_launch_template" {
 #!/bin/bash
 echo "export AWS_REGION=${data.aws_region.current.name}" >> /etc/environment
 source /etc/environment
+
+# Fix sandbox image before nodeadm runs
+sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
+
+# Restart containerd to apply config
+systemctl restart containerd
+
 cat <<EOF > /etc/eks/nodeadm-config.yaml
 apiVersion: node.eks.aws/v1alpha1
 kind: NodeConfig
@@ -33,10 +40,6 @@ spec:
     certificateAuthority: |
       ${var.certificate_authority}
     cidr: ${var.service_ipv4_cidr}
-  containerd:
-    config: |
-      [plugins."io.containerd.grpc.v1.cri"]
-        sandbox_image = "${var.pause_container_image}"
 EOF
 
 /usr/local/bin/nodeadm init -c file:///etc/eks/nodeadm-config.yaml


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
Replace the pause config directly in the containerd config instead of using nodeConfig. We're experiencing sandbox change and pods getting restarted. Using the nodeConfig, it keeps the default config in the `config.toml` and adds the new one in the conf.d folder.

```
Normal   SandboxChanged  16s (x2 over 26s)  kubelet            Pod sandbox changed, it will be killed and re-created.
```

#### Ticket Link
git checkout -b CLD-9467-fix-pause-image-address-for-al-2023

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
NONE
```
