### PR TITLE
Fix userdata to add pause container image

### DIFF
--- a/aws/eks-managed-node-groups/graviton_node_groups.tf
+++ b/aws/eks-managed-node-groups/graviton_node_groups.tf
@@ -24,7 +24,7 @@ resource "aws_launch_template" "cluster_nodes_eks_arm_launch_template" {
 echo "export AWS_REGION=${data.aws_region.current.name}" >> /etc/environment
 source /etc/environment
 
-# Fix sandbox image before nodeadm runs
+# Fix sandbox image
 sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
 
 # Restart containerd to apply config
@@ -44,9 +44,22 @@ spec:
   kubelet:
     config:
       maxPods: ${lookup(var.instance_type_max_pods_map, var.arm_instance_type, 17)}
+  containerd:
+    config: |
+      [plugins."io.containerd.grpc.v1.cri"]
+        sandbox_image = "${var.pause_container_image}"
 EOF
 
-/usr/local/bin/nodeadm init -c file:///etc/eks/nodeadm-config.yaml
+/usr/local/bin/nodeadm --config /etc/eks/nodeadm-config.yaml
+
+# Fix sandbox image before nodeadm runs
+sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
+
+# Remove any existing containerd config.d directory
+[ -d /etc/containerd/config.d ] && rm -rf /etc/containerd/config.d
+
+# Restart containerd to apply config
+systemctl restart containerd
 USERDATA
     ) : base64encode(<<USERDATA
 #!/bin/bash
@@ -92,7 +105,7 @@ resource "aws_launch_template" "calico_cluster_nodes_eks_arm_launch_template" {
 echo "export AWS_REGION=${data.aws_region.current.name}" >> /etc/environment
 source /etc/environment
 
-# Fix sandbox image before nodeadm runs
+# Fix sandbox image
 sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
 
 # Restart containerd to apply config
@@ -112,9 +125,22 @@ spec:
   kubelet:
     config:
       maxPods: ${var.calico_max_pods}
+  containerd:
+    config: |
+      [plugins."io.containerd.grpc.v1.cri"]
+        sandbox_image = "${var.pause_container_image}"
 EOF
 
-/usr/local/bin/nodeadm init -c file:///etc/eks/nodeadm-config.yaml
+/usr/local/bin/nodeadm --config /etc/eks/nodeadm-config.yaml
+
+# Fix sandbox image before nodeadm runs
+sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
+
+# Remove any existing containerd config.d directory
+[ -d /etc/containerd/config.d ] && rm -rf /etc/containerd/config.d
+
+# Restart containerd to apply config
+systemctl restart containerd
 USERDATA
     ) : base64encode(<<USERDATA
 #!/bin/bash

--- a/aws/eks-managed-node-groups/node_groups.tf
+++ b/aws/eks-managed-node-groups/node_groups.tf
@@ -23,7 +23,7 @@ resource "aws_launch_template" "cluster_nodes_eks_launch_template" {
 echo "export AWS_REGION=${data.aws_region.current.name}" >> /etc/environment
 source /etc/environment
 
-# Fix sandbox image before nodeadm runs
+# Fix sandbox image
 sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
 
 # Restart containerd to apply config
@@ -40,9 +40,22 @@ spec:
     certificateAuthority: |
       ${var.certificate_authority}
     cidr: ${var.service_ipv4_cidr}
+  containerd:
+    config: |
+      [plugins."io.containerd.grpc.v1.cri"]
+        sandbox_image = "${var.pause_container_image}"
 EOF
 
-/usr/local/bin/nodeadm init -c file:///etc/eks/nodeadm-config.yaml
+/usr/local/bin/nodeadm --config /etc/eks/nodeadm-config.yaml
+
+# Fix sandbox image before nodeadm runs
+sed -i 's|sandbox_image = .*|sandbox_image = "${var.pause_container_image}"|' /etc/containerd/config.toml
+
+# Remove any existing containerd config.d directory
+[ -d /etc/containerd/config.d ] && rm -rf /etc/containerd/config.d
+
+# Restart containerd to apply config
+systemctl restart containerd
 USERDATA
     ) : base64encode(<<USERDATA
 #!/bin/bash


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
We need to run nodeadm command passing the pause container in nodeConfig and after that fix default config.toml and remove config.d folder.

#### Ticket Link
git checkout -b CLD-9467-fix-pause-image-address-for-al-2023

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
None
```
