### PR TITLE
Refactor network interface configuration and update AWS provider version

### DIFF
--- a/aws/pexip-multi-conferences/ec2.tf
+++ b/aws/pexip-multi-conferences/ec2.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "pexip_management" {
   instance_type = var.management_ec2_type
   key_name      = var.initial_configuration ? var.ec2_key_pair : ""
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.pexip_management.id
     device_index         = 0
   }
@@ -36,7 +36,7 @@ resource "aws_instance" "pexip_conference" {
   key_name      = var.initial_configuration ? var.ec2_key_pair : ""
   tenancy       = "dedicated"
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.pexip_conference[each.key].id
     device_index         = 0
   }

--- a/aws/pexip-multi-conferences/elb.tf
+++ b/aws/pexip-multi-conferences/elb.tf
@@ -97,7 +97,7 @@ resource "aws_load_balancer_policy" "pexip_management_ssl_policy" {
 
   policy_attribute {
     name  = "Reference-Security-Policy"
-    value = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+    value = "ELBSecurityPolicy-TLS-1-2-2017-01"
   }
 }
 
@@ -122,7 +122,7 @@ resource "aws_load_balancer_policy" "pexip_conference_ssl_policy" {
 
   policy_attribute {
     name  = "Reference-Security-Policy"
-    value = "ELBSecurityPolicy-TLS13-1-2-Res-2021-06"
+    value = "ELBSecurityPolicy-TLS-1-2-2017-01"
   }
 }
 

--- a/aws/pexip-multi-conferences/providers.tf
+++ b/aws/pexip-multi-conferences/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.41.0"
+      version = ">= 6.11.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"

--- a/aws/pexip/ec2.tf
+++ b/aws/pexip/ec2.tf
@@ -9,7 +9,7 @@ resource "aws_instance" "pexip_management" {
   instance_type = var.management_ec2_type
   key_name      = var.initial_configuration ? var.ec2_key_pair : ""
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.pexip_management.id
     device_index         = 0
   }
@@ -31,7 +31,7 @@ resource "aws_instance" "pexip_conference" {
   key_name      = var.initial_configuration ? var.ec2_key_pair : ""
   tenancy       = "dedicated"
 
-  network_interface {
+  primary_network_interface {
     network_interface_id = aws_network_interface.pexip_conference.id
     device_index         = 0
   }

--- a/aws/pexip/providers.tf
+++ b/aws/pexip/providers.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.41.0"
+      version = ">= 6.11.0"
     }
     cloudflare = {
       source  = "cloudflare/cloudflare"


### PR DESCRIPTION
#### Summary
- Changed 'network_interface' to 'primary_network_interface' in EC2 instances for management and conference.
- Updated AWS provider version requirement from '>= 5.41.0' to '>= 6.11.0' in both pexip and pexip-multi-conferences modules.
- Modified ELB SSL policies to use 'ELBSecurityPolicy-TLS-1-2-2017-01' for enhanced security.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note

```
