### PR TITLE
Update Pexip ELB and security group configurations

### DIFF
--- a/aws/pexip-multi-conferences/README.md
+++ b/aws/pexip-multi-conferences/README.md
@@ -41,6 +41,7 @@ No modules.
 | [aws_security_group.pexip_conference_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.pexip_management_elb_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
 | [aws_security_group.pexip_management_sg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_security_group_rule.pexip_conference_bootstrap_direct](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_elb_bootstrap](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_elb_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -48,13 +49,14 @@ No modules.
 | [aws_security_group_rule.pexip_conference_elb_sip](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_elb_sip_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_elb_to_conf_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.pexip_conference_elb_to_conf_5060](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_elb_to_conf_5061](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_elb_to_conf_8443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_from_elb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.pexip_conference_from_elb_5060](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_from_elb_5061](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_from_elb_8443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.pexip_conference_from_management_esp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.pexip_conference_from_management_udp_500](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.pexip_conference_from_management](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_udp_ports](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_conference_vpn_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_management_egress_all](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
@@ -62,8 +64,7 @@ No modules.
 | [aws_security_group_rule.pexip_management_elb_https_vpn](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_management_elb_ssh](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_management_elb_to_mgmt_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.pexip_management_from_conference_esp](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
-| [aws_security_group_rule.pexip_management_from_conference_udp_500](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
+| [aws_security_group_rule.pexip_management_from_conference](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_management_from_elb_22](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_management_from_elb_443](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |
 | [aws_security_group_rule.pexip_management_initial_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group_rule) | resource |

--- a/aws/pexip-multi-conferences/elb.tf
+++ b/aws/pexip-multi-conferences/elb.tf
@@ -59,11 +59,10 @@ resource "aws_elb" "pexip_conference_elb" {
   dynamic "listener" {
     for_each = var.initial_configuration ? [1] : []
     content {
-      instance_port      = 8443
-      instance_protocol  = "https"
-      lb_port            = 8443
-      lb_protocol        = "https"
-      ssl_certificate_id = var.elb_ssl_certificate_arn_public
+      instance_port     = 8443
+      instance_protocol = "tcp"
+      lb_port           = 8443
+      lb_protocol       = "tcp"
     }
   }
 

--- a/aws/pexip-multi-conferences/sg.tf
+++ b/aws/pexip-multi-conferences/sg.tf
@@ -57,34 +57,34 @@ resource "aws_security_group_rule" "pexip_conference_vpn_access" {
   type              = "ingress"
   from_port         = 0
   to_port           = 0
-  protocol          = "tcp"
+  protocol          = "-1"
   cidr_blocks       = var.vpn_ips
   security_group_id = aws_security_group.pexip_conference_sg.id
   description       = "VPN access"
 }
 
-# Conference SG ingress rules - Inter-node communication
-resource "aws_security_group_rule" "pexip_conference_from_management_udp_500" {
-  type              = "ingress"
-  from_port         = 500
-  to_port           = 500
-  protocol          = "udp"
-  cidr_blocks       = [for ip in var.management_private_ips : "${ip}/32"]
-  security_group_id = aws_security_group.pexip_conference_sg.id
-  description       = "ISAKMP (IPsec) inter-node communication from management nodes"
-}
-
-resource "aws_security_group_rule" "pexip_conference_from_management_esp" {
+# Conference SG ingress rules - Inter-node communication (all protocols needed for config sync)
+resource "aws_security_group_rule" "pexip_conference_from_management" {
   type              = "ingress"
   from_port         = 0
   to_port           = 0
-  protocol          = "50"
+  protocol          = "-1"
   cidr_blocks       = [for ip in var.management_private_ips : "${ip}/32"]
   security_group_id = aws_security_group.pexip_conference_sg.id
-  description       = "IPsec / IP Protocol 50 inter-node communication from management nodes"
+  description       = "All access from management nodes"
 }
 
 # Conference SG ingress rules - From ELB
+resource "aws_security_group_rule" "pexip_conference_from_elb_5060" {
+  type                     = "ingress"
+  from_port                = 5060
+  to_port                  = 5060
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.pexip_conference_elb_sg.id
+  security_group_id        = aws_security_group.pexip_conference_sg.id
+  description              = "SIP from ELB"
+}
+
 resource "aws_security_group_rule" "pexip_conference_from_elb_443" {
   type                     = "ingress"
   from_port                = 443
@@ -116,6 +116,17 @@ resource "aws_security_group_rule" "pexip_conference_from_elb_8443" {
   description              = "upload configuration/bootstrap port from ELB"
 }
 
+resource "aws_security_group_rule" "pexip_conference_bootstrap_direct" {
+  count             = var.initial_configuration ? 1 : 0
+  type              = "ingress"
+  from_port         = 8443
+  to_port           = 8443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.pexip_conference_sg.id
+  description       = "Direct bootstrap upload"
+}
+
 # Conference SG egress rules
 resource "aws_security_group_rule" "pexip_conference_egress_all" {
   type              = "egress"
@@ -139,25 +150,15 @@ resource "aws_security_group_rule" "pexip_management_initial_config" {
   description       = var.management_public ? "initial configuration of Pexip management node (public)" : "initial configuration of Pexip management node"
 }
 
-# Management SG ingress rules - Inter-node communication
-resource "aws_security_group_rule" "pexip_management_from_conference_udp_500" {
-  type              = "ingress"
-  from_port         = 500
-  to_port           = 500
-  protocol          = "udp"
-  cidr_blocks       = [for node in var.conference_nodes : "${node.private_ip}/32"]
-  security_group_id = aws_security_group.pexip_management_sg.id
-  description       = "ISAKMP (IPsec) inter-node communication from conference nodes"
-}
-
-resource "aws_security_group_rule" "pexip_management_from_conference_esp" {
+# Management SG ingress rules - Inter-node communication (all protocols needed for config sync)
+resource "aws_security_group_rule" "pexip_management_from_conference" {
   type              = "ingress"
   from_port         = 0
   to_port           = 0
-  protocol          = "50"
+  protocol          = "-1"
   cidr_blocks       = [for node in var.conference_nodes : "${node.private_ip}/32"]
   security_group_id = aws_security_group.pexip_management_sg.id
-  description       = "IPsec / IP Protocol 50 inter-node communication from conference nodes"
+  description       = "All access from conference nodes"
 }
 
 # Management SG ingress rules - From ELB
@@ -287,6 +288,16 @@ resource "aws_security_group_rule" "pexip_conference_elb_to_conf_443" {
   source_security_group_id = aws_security_group.pexip_conference_sg.id
   security_group_id        = aws_security_group.pexip_conference_elb_sg.id
   description              = "HTTPS to conference nodes"
+}
+
+resource "aws_security_group_rule" "pexip_conference_elb_to_conf_5060" {
+  type                     = "egress"
+  from_port                = 5060
+  to_port                  = 5060
+  protocol                 = "tcp"
+  source_security_group_id = aws_security_group.pexip_conference_sg.id
+  security_group_id        = aws_security_group.pexip_conference_elb_sg.id
+  description              = "SIP to conference nodes"
 }
 
 resource "aws_security_group_rule" "pexip_conference_elb_to_conf_5061" {


### PR DESCRIPTION
#### Summary
- Changed ELB listener protocol from HTTPS to TCP for improved compatibility.
- Added new security group rules for SIP traffic from ELB and direct bootstrap uploads.
- Updated README to reflect new security group rules and clarify access configurations.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Update Pexip ELB and security group configurations
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added direct bootstrap configuration access for initial setup.
  * Added load balancer support for SIP communication on port 5060.

* **Improvements**
  * Consolidated inter-node security rules for streamlined access management.
  * Expanded VPN access to support all protocols.
  * Changed load balancer listener to TCP pass-through mode for enhanced compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->