### PR TITLE
Remove unused SSL negotiation policy for ELB listener on port 8443 in…

### DIFF
--- a/aws/pexip-multi-conferences/elb.tf
+++ b/aws/pexip-multi-conferences/elb.tf
@@ -145,15 +145,3 @@ resource "aws_load_balancer_listener_policy" "pexip_conference_listener_policy_4
     aws_load_balancer_policy.pexip_conference_ssl_policy[each.key].policy_name,
   ]
 }
-
-# SSL Negotiation Policy for Conference ELBs port 8443 (only when initial_configuration is true)
-resource "aws_load_balancer_listener_policy" "pexip_conference_listener_policy_8443" {
-  for_each = var.initial_configuration ? var.conference_nodes : {}
-
-  load_balancer_name = aws_elb.pexip_conference_elb[each.key].name
-  load_balancer_port = 8443
-
-  policy_names = [
-    aws_load_balancer_policy.pexip_conference_ssl_policy[each.key].policy_name,
-  ]
-}


### PR DESCRIPTION
… Pexip multi-conferences module.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined conference load balancer configuration by removing the 8443 port listener policy settings. This change simplifies policy management and reduces complexity in the overall infrastructure configuration for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->