### PR TITLE
Refactor EC2 instance configurations in Pexip multi-conferences module

### DIFF
--- a/aws/pexip-multi-conferences/ec2.tf
+++ b/aws/pexip-multi-conferences/ec2.tf
@@ -20,9 +20,9 @@ resource "aws_eip_association" "pexip_management" {
 }
 
 resource "aws_instance" "pexip_management" {
-  ami           = var.initial_configuration ? var.official_pexip_management_ec2_ami : var.custom_management_ec2_ami
+  ami           = var.official_pexip_management_ec2_ami
   instance_type = var.management_ec2_type
-  key_name      = var.initial_configuration ? var.ec2_key_pair : ""
+  key_name      = var.ec2_key_pair
 
   primary_network_interface {
     network_interface_id = aws_network_interface.pexip_management.id
@@ -45,9 +45,9 @@ resource "aws_network_interface" "pexip_conference" {
 resource "aws_instance" "pexip_conference" {
   for_each = var.conference_nodes
 
-  ami           = var.initial_configuration ? var.official_pexip_conference_ec2_ami : each.value.ami_id
+  ami           = var.official_pexip_conference_ec2_ami
   instance_type = each.value.ec2_type
-  key_name      = var.initial_configuration ? var.ec2_key_pair : ""
+  key_name      = var.ec2_key_pair
   tenancy       = "dedicated"
 
   primary_network_interface {

--- a/aws/pexip-multi-conferences/variables.tf
+++ b/aws/pexip-multi-conferences/variables.tf
@@ -33,7 +33,6 @@ variable "conference_nodes" {
     dns_name   = string
     ec2_type   = string
     private_ip = string
-    ami_id     = string
   }))
   description = "Map of conference nodes with their properties"
   default = {
@@ -41,13 +40,11 @@ variable "conference_nodes" {
       dns_name   = "random.mattermost.com"
       ec2_type   = "c6i.large"
       private_ip = "10.0.1.10"
-      ami_id     = "ami-0d48fecb4209bb660"
     },
     "example" = {
       dns_name   = "example.mattermost.com"
       ec2_type   = "c6i.xlarge"
       private_ip = "10.0.1.11"
-      ami_id     = "ami-0d48fecb4209bb660"
     }
   }
 }
@@ -79,11 +76,6 @@ variable "official_pexip_conference_ec2_ami" {
   description = "The official AMI 686087431763/Pexip Infinity Conference Node 37.0.0 (build 80989.0.0)"
 }
 
-variable "custom_management_ec2_ami" {
-  type        = string
-  description = "Customized with MM configuration Pexip AMI for management node"
-}
-
 variable "management_ec2_type" {
   type        = string
   description = "The EC2 instance type for Pexip management node"
@@ -95,7 +87,7 @@ variable "ec2_key_pair" {
 }
 
 variable "initial_configuration" {
-  description = "A boolean variable to control the initial configuration of Pexip setup, when true official AMI will be deployed and key-pairs will be added to EC2 nodes"
+  description = "When true, opens bootstrap port 8443, SSH port 22, and relaxed SG rules for initial Pexip setup. Set to false after configuration is complete."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
#### Summary
- Removed conditional logic for AMI selection in `pexip_management` and `pexip_conference` instances, now using official AMIs directly.
- Simplified key name assignment for EC2 instances by removing initial configuration dependency.
- Removed unused `ami_id` field from `conference_nodes` variable and cleaned up related comments in `variables.tf`.
- Updated description for `initial_configuration` variable to clarify its purpose.

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->

#### Release Note
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

-->

```release-note
Refactor EC2 instance configurations in Pexip multi-conferences module
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified AWS infrastructure configuration by removing custom AMI selection options and streamlining EC2 instance setup logic. Configuration now uses standard AMI references and SSH key pair assignments directly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->