### PR TITLE
Add github-cursor-webhook lambda + API Gateway route

### DIFF
--- a/aws/generic-webhook-notification/api-gateway.tf
+++ b/aws/generic-webhook-notification/api-gateway.tf
@@ -71,3 +71,26 @@ resource "aws_api_gateway_integration" "gitlab-webhook-integration" {
   type                    = "AWS_PROXY"
   uri                     = aws_lambda_function.gitlab-webhook.invoke_arn
 }
+
+resource "aws_api_gateway_resource" "github-cursor-webhook-resource" {
+  rest_api_id = aws_api_gateway_rest_api.core-generic-webhook-notification.id
+  parent_id   = var.parent_id
+  path_part   = "github-cursor-webhook"
+}
+
+resource "aws_api_gateway_method" "github-cursor-webhook-post" {
+  rest_api_id   = aws_api_gateway_rest_api.core-generic-webhook-notification.id
+  resource_id   = aws_api_gateway_resource.github-cursor-webhook-resource.id
+  http_method   = "POST"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "github-cursor-webhook-integration" {
+  rest_api_id = aws_api_gateway_rest_api.core-generic-webhook-notification.id
+  resource_id = aws_api_gateway_resource.github-cursor-webhook-resource.id
+  http_method = aws_api_gateway_method.github-cursor-webhook-post.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.github-cursor-webhook.invoke_arn
+}

--- a/aws/generic-webhook-notification/lambdas.tf
+++ b/aws/generic-webhook-notification/lambdas.tf
@@ -109,6 +109,41 @@ resource "aws_lambda_function" "gitlab-webhook" {
 
 }
 
+resource "aws_lambda_function" "github-cursor-webhook" {
+  function_name = "${var.deployment_name}-github-cursor-webhook"
+  runtime       = "provided.al2"
+  role          = aws_iam_role.generic-webhook.arn
+  memory_size   = 128
+  timeout       = 30
+  handler       = "bootstrap"
+  architectures = var.enable_arm64 ? ["arm64"] : ["x86_64"]
+
+  s3_bucket = var.lambda_s3_bucket
+  s3_key    = var.lambda_github_cursor_webhook_s3_key
+
+  vpc_config {
+    subnet_ids         = flatten(var.private_subnet_ids)
+    security_group_ids = [aws_security_group.generic-lambda_sg.id]
+  }
+
+  tracing_config {
+    mode = "PassThrough"
+  }
+
+  environment {
+    variables = {
+      N8N_WEBHOOK_URL = var.github_cursor_webhook_n8n_url
+      WEBHOOK_SECRET  = var.github_cursor_webhook_secret
+    }
+  }
+
+  ephemeral_storage {
+    size = 512
+  }
+
+  tags = var.tags
+}
+
 resource "aws_lambda_permission" "provisioner-notification-permission" {
   statement_id  = "AllowExecutionFromAPIGateway"
   action        = "lambda:InvokeFunction"
@@ -135,6 +170,15 @@ resource "aws_lambda_permission" "gitlab-webhook-permission" {
   principal     = "apigateway.amazonaws.com"
 
   source_arn = "${aws_api_gateway_rest_api.core-generic-webhook-notification.execution_arn}/*/${aws_api_gateway_method.gitlab-webhook-post.http_method}/${aws_api_gateway_resource.gitlab-webhook-resource.path_part}"
+}
+
+resource "aws_lambda_permission" "github-cursor-webhook-permission" {
+  statement_id  = "AllowExecutionFromAPIGateway"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.github-cursor-webhook.function_name
+  principal     = "apigateway.amazonaws.com"
+
+  source_arn = "${aws_api_gateway_rest_api.core-generic-webhook-notification.execution_arn}/*/${aws_api_gateway_method.github-cursor-webhook-post.http_method}/${aws_api_gateway_resource.github-cursor-webhook-resource.path_part}"
 }
 
 resource "aws_security_group" "generic-lambda_sg" {

--- a/aws/generic-webhook-notification/lambdas.tf
+++ b/aws/generic-webhook-notification/lambdas.tf
@@ -132,8 +132,9 @@ resource "aws_lambda_function" "github-cursor-webhook" {
 
   environment {
     variables = {
-      N8N_WEBHOOK_URL = var.github_cursor_webhook_n8n_url
-      WEBHOOK_SECRET  = var.github_cursor_webhook_secret
+      N8N_WEBHOOK_URL       = var.github_cursor_webhook_n8n_url
+      GITHUB_WEBHOOK_SECRET = var.github_cursor_webhook_github_secret
+      N8N_API_KEY           = var.github_cursor_webhook_n8n_api_key
     }
   }
 

--- a/aws/generic-webhook-notification/variables.tf
+++ b/aws/generic-webhook-notification/variables.tf
@@ -62,12 +62,33 @@ variable "lambda_github_cursor_webhook_s3_key" {
 variable "github_cursor_webhook_n8n_url" {
   type        = string
   description = "Downstream n8n webhook URL that the github-cursor-webhook lambda forwards filtered events to"
+
+  validation {
+    condition     = can(regex("^https://", var.github_cursor_webhook_n8n_url))
+    error_message = "github_cursor_webhook_n8n_url must be an https URL."
+  }
 }
 
-variable "github_cursor_webhook_secret" {
+variable "github_cursor_webhook_github_secret" {
   type        = string
-  description = "Shared secret expected on the ?secret query string for inbound github-cursor-webhook requests"
+  description = "Shared secret configured on the GitHub webhook; used to verify the X-Hub-Signature-256 HMAC on inbound requests"
   sensitive   = true
+
+  validation {
+    condition     = length(var.github_cursor_webhook_github_secret) >= 16
+    error_message = "github_cursor_webhook_github_secret must be at least 16 characters."
+  }
+}
+
+variable "github_cursor_webhook_n8n_api_key" {
+  type        = string
+  description = "API key sent as the X-API-KEY header on outbound forwards to the n8n workflow"
+  sensitive   = true
+
+  validation {
+    condition     = length(var.github_cursor_webhook_n8n_api_key) >= 16
+    error_message = "github_cursor_webhook_n8n_api_key must be at least 16 characters."
+  }
 }
 
 variable "parent_id" {

--- a/aws/generic-webhook-notification/variables.tf
+++ b/aws/generic-webhook-notification/variables.tf
@@ -54,6 +54,22 @@ variable "lambda_provisioner_notification_s3_key" {
   description = "The S3 key where the provisioner notification lambda function is stored"
 }
 
+variable "lambda_github_cursor_webhook_s3_key" {
+  type        = string
+  description = "The S3 key where the github-cursor-webhook lambda function is stored"
+}
+
+variable "github_cursor_webhook_n8n_url" {
+  type        = string
+  description = "Downstream n8n webhook URL that the github-cursor-webhook lambda forwards filtered events to"
+}
+
+variable "github_cursor_webhook_secret" {
+  type        = string
+  description = "Shared secret expected on the ?secret query string for inbound github-cursor-webhook requests"
+  sensitive   = true
+}
+
 variable "parent_id" {
   type = string
 }


### PR DESCRIPTION
#### Summary

Provisions the new pre-filtering lambda from mattermost/mattermost-cloud-lambdas alongside the existing entries in `aws/generic-webhook-notification`:

- `aws_lambda_function.github-cursor-webhook` (shares the existing `generic-webhook` IAM role, security group, and VPC config).
- `aws_lambda_permission` granting API Gateway invoke.
- `/github-cursor-webhook` POST resource + AWS_PROXY integration on the existing `core-generic-webhook-notification` REST API.
- Three new required variables: `lambda_github_cursor_webhook_s3_key`, `github_cursor_webhook_n8n_url`, `github_cursor_webhook_secret` (sensitive).

Companion PR: mattermost/mattermost-cloud-lambdas#119.

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

Made with [Cursor](https://cursor.com)